### PR TITLE
Fix breaks in Python 3.5 due to pathlib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
         - secure: "drOQIoP0IbVf+NbjbyH2nGEixtt4R/1tBQYr7EBjo2IDXI8/b5io7voL2jsaAhhCGZpzaLJvvv1gVUj9FxJFfhiQKwyU2F4n0E1TLJFFVfxXWMUFh6rrCAAbfuBhhzRDsbVNtH29FYPhNJKj8D2YsLkAydoRfMDMli0DJrn0qPO+/My0Dk7ikaPLo1/UDRLSUBae95yGbex3B/ksTZdELIVAZiSb7SWkL//cQpl+UcP/tvAWxsz+XIWH2TJ8d8anOSnZv7ccCkVx1P8DDp1LxhvY3vSiSV9KE3WDTWJzgmuvC34e5sPqxPoQjDklHjCQHtV4p2hi7tNAFX9yESUjSpFS8LDGMgQRrt6s5y3+KmQ4Qg/lJTNnRVIu/L6cxH9NPFd8bmJevQO532Qu8d5aiNmgAQb1/m8ZuEZCebXxXSMTD1Pl+b3xS/folhqyKhh31pLb7JPwhjSTdim08ZjISdRIqNVes2dNYgfqaF7RNrho4ha0Cj7NpRW1YEYw+n0kVjFmZuIoWyNXClfAfn03r69XgXLAh51HmW1OeXrdRr6Ji7sbVLyu5AMkGEt92G9dJARqb+E+hHk4p+5Htp/U7rRzcUsXhMYKaMY4d9D8uCRNNbAFnKqOlOUXq3FaVG/qAi4Y4YskYtHs3veKjnP/TRdIEugFuEZjeaADFLR6YWA="
         - TWINE_USERNAME=Leonardo.Uieda
         # The file with the listed requirements to be installed by conda
-        - REQUIREMENTS=requirements.txt
+        - CONDA_REQUIREMENTS=requirements.txt
         # These variables control which actions are performed in a build
         - COVERAGE=false
         - BUILD_DOCS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,8 @@ install:
 script:
     # Check code for style and quality
     - if [ "$CHECK_FORMAT" == "true" ]; then
+          # Black is Python 3.6 only so it can't be in the requirements file.
+          conda install --yes --channel conda-forge black python=$PYTHON
           make check;
       fi
     # Run the test suite

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,9 +61,6 @@ matrix:
 
 # Setup the build environment
 before_install:
-    # Copy sample data to the verde data dir to avoid downloading all the time
-    #- mkdir -p $HOME/.verde/data
-    #- cp data/* $HOME/.verde/data
     # Get the Fatiando CI scripts
     - git clone https://github.com/fatiando/continuous-integration.git
     # Download and install miniconda and setup dependencies
@@ -81,8 +78,8 @@ install:
 # Run the actual tests and checks
 script:
     # Check code for style and quality
+    # Black is Python 3.6 only so it can't be in the requirements file.
     - if [ "$CHECK_FORMAT" == "true" ]; then
-          # Black is Python 3.6 only so it can't be in the requirements file.
           conda install --yes --channel conda-forge black python=$PYTHON;
           make check;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
     # Check code for style and quality
     - if [ "$CHECK_FORMAT" == "true" ]; then
           # Black is Python 3.6 only so it can't be in the requirements file.
-          conda install --yes --channel conda-forge black python=$PYTHON
+          conda install --yes --channel conda-forge black python=$PYTHON;
           make check;
       fi
     # Run the test suite

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
         - secure: "drOQIoP0IbVf+NbjbyH2nGEixtt4R/1tBQYr7EBjo2IDXI8/b5io7voL2jsaAhhCGZpzaLJvvv1gVUj9FxJFfhiQKwyU2F4n0E1TLJFFVfxXWMUFh6rrCAAbfuBhhzRDsbVNtH29FYPhNJKj8D2YsLkAydoRfMDMli0DJrn0qPO+/My0Dk7ikaPLo1/UDRLSUBae95yGbex3B/ksTZdELIVAZiSb7SWkL//cQpl+UcP/tvAWxsz+XIWH2TJ8d8anOSnZv7ccCkVx1P8DDp1LxhvY3vSiSV9KE3WDTWJzgmuvC34e5sPqxPoQjDklHjCQHtV4p2hi7tNAFX9yESUjSpFS8LDGMgQRrt6s5y3+KmQ4Qg/lJTNnRVIu/L6cxH9NPFd8bmJevQO532Qu8d5aiNmgAQb1/m8ZuEZCebXxXSMTD1Pl+b3xS/folhqyKhh31pLb7JPwhjSTdim08ZjISdRIqNVes2dNYgfqaF7RNrho4ha0Cj7NpRW1YEYw+n0kVjFmZuIoWyNXClfAfn03r69XgXLAh51HmW1OeXrdRr6Ji7sbVLyu5AMkGEt92G9dJARqb+E+hHk4p+5Htp/U7rRzcUsXhMYKaMY4d9D8uCRNNbAFnKqOlOUXq3FaVG/qAi4Y4YskYtHs3veKjnP/TRdIEugFuEZjeaADFLR6YWA="
         - TWINE_USERNAME=Leonardo.Uieda
         # The file with the listed requirements to be installed by conda
-        - CONDA_REQUIREMENTS=requirements.txt
+        - REQUIREMENTS=requirements.txt
         # These variables control which actions are performed in a build
         - COVERAGE=false
         - BUILD_DOCS=false

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -33,8 +33,8 @@ def create(path, base_url, version, version_dev, env=None, registry=None):
     ----------
     path : str, PathLike, list or tuple
         The path to the local data storage folder. If this is a list or tuple, we'll
-        call :func:`os.path.join` on it. The *version* will be appended to the end of
-        this path. Use :func:`pooch.os_cache` for a sensible default.
+        join the parts with the appropriate separator. The *version* will be appended to
+        the end of this path. Use :func:`pooch.os_cache` for a sensible default.
     base_url : str
         Base URL for the remote data source. All requests will be made relative to this
         URL. The string should have a ``{version}`` formatting mark in it. We will call
@@ -138,7 +138,7 @@ def create(path, base_url, version, version_dev, env=None, registry=None):
         path = Path(os.environ[env])
     versioned_path = Path(path, version)
     # Create the directory if it doesn't already exist
-    os.makedirs(versioned_path.expanduser().resolve(), exist_ok=True)
+    versioned_path.expanduser().mkdir(parents=True, exist_ok=True)
     if registry is None:
         registry = dict()
     pup = Pooch(
@@ -209,7 +209,7 @@ class Pooch:
     @property
     def abspath(self):
         "Absolute path to the local storage"
-        return Path(os.path.abspath(os.path.expanduser(self.path)))
+        return Path(self.path).expanduser().resolve()
 
     def fetch(self, fname):
         """
@@ -236,13 +236,13 @@ class Pooch:
         """
         if fname not in self.registry:
             raise ValueError("File '{}' is not in the registry.".format(fname))
-        full_path = os.path.join(self.abspath, fname)
-        in_storage = os.path.exists(full_path)
-        update = in_storage and file_hash(full_path) != self.registry[fname]
+        full_path = self.abspath / fname
+        in_storage = full_path.exists()
+        update = in_storage and file_hash(str(full_path)) != self.registry[fname]
         download = not in_storage
         if update or download:
             self._download_file(fname, update)
-        return full_path
+        return str(full_path)
 
     def _download_file(self, fname, update):
         """
@@ -262,7 +262,7 @@ class Pooch:
             If the hash of the downloaded file doesn't match the hash in the registry.
 
         """
-        destination = os.path.join(self.abspath, fname)
+        destination = self.abspath / fname
         source = "".join([self.base_url, fname])
         if update:
             action = "Updating"
@@ -270,7 +270,7 @@ class Pooch:
             action = "Downloading"
         warn(
             "{} data file '{}' from remote data store '{}' to '{}'.".format(
-                action, fname, self.base_url, self.abspath
+                action, fname, self.base_url, str(self.abspath)
             )
         )
         response = requests.get(source, stream=True)
@@ -289,7 +289,7 @@ class Pooch:
                     fout.name, self.registry[fname], tmphash
                 )
             )
-        shutil.move(fout.name, destination)
+        shutil.move(fout.name, str(destination))
 
     def load_registry(self, fname):
         """

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -270,7 +270,7 @@ class Pooch:
             action = "Downloading"
         warn(
             "{} data file '{}' from remote data store '{}' to '{}'.".format(
-                action, fname, self.base_url, str(self.abspath)
+                action, fname, self.base_url, str(self.path)
             )
         )
         response = requests.get(source, stream=True)

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -2,6 +2,7 @@
 Test the core class and factory function.
 """
 import os
+from pathlib import Path
 from tempfile import TemporaryDirectory
 import warnings
 
@@ -12,7 +13,7 @@ from ..utils import file_hash
 from .utils import pooch_test_url, pooch_test_registry, check_tiny_data
 
 
-DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
+DATA_DIR = str(Path(os.path.dirname(__file__), "data").expanduser().resolve())
 REGISTRY = pooch_test_registry()
 BASEURL = pooch_test_url()
 REGISTRY_CORRUPTED = {
@@ -33,10 +34,10 @@ def test_pooch_local():
 def test_pooch_update():
     "Setup a pooch that already has the local data but the file is outdated"
     with TemporaryDirectory() as local_store:
-        path = os.path.abspath(os.path.expanduser(local_store))
+        path = Path(local_store).expanduser().resolve()
         # Create a dummy version of tiny-data.txt that is different from the one in the
         # remote storage
-        true_path = os.path.join(path, "tiny-data.txt")
+        true_path = str(path / "tiny-data.txt")
         with open(true_path, "w") as fin:
             fin.write("different data")
         # Setup a pooch in a temp dir

--- a/pooch/tests/test_integration.py
+++ b/pooch/tests/test_integration.py
@@ -23,16 +23,17 @@ def pup():
         version_dev="master",
         env="POOCH_DATA_DIR",
     )
-    gar.load_registry(Path(os.path.dirname(__file__), "data", "registry.txt"))
+    # The str conversion is needed in Python 3.5
+    gar.load_registry(str(Path(os.path.dirname(__file__), "data", "registry.txt")))
     yield gar
-    shutil.rmtree(gar.abspath)
+    shutil.rmtree(str(gar.abspath))
 
 
 def test_fetch(pup):
     "Fetch a data file from the local storage"
     # Make sure the storage exists and is empty to begin
     assert pup.abspath.exists()
-    assert not os.listdir(pup.abspath)
+    assert not list(pup.abspath.iterdir())
     with warnings.catch_warnings(record=True) as warn:
         fname = pup.fetch("tiny-data.txt")
         assert len(warn) == 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ sphinx_rtd_theme
 numpydoc
 twine
 # Black is not included because it requires Python 3.6
-black
+#black

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,10 @@ packaging
 pytest
 pytest-cov
 coverage
-black
 pylint
 sphinx
 sphinx_rtd_theme
 numpydoc
 twine
+# Black is not included because it requires Python 3.6
+black


### PR DESCRIPTION
Because Black is Python 3.6 only, our CI builds were silently
upgrading Python to 3.6. So our 3.5 builds weren't actually 3.5.
Removing black from the `requirements.txt` and install it 
manually on `.travis.yml` when running the checks works.
Leave it in the `environment.yml` so that devs will get it installed.

Breaks on 3.5 are related to mixing `os.path` and `pathlib`.
Use pathlib in most places now and include `str` conversions
because 3.5 doesn't support passing Path to `open` etc.
