### PR TITLE
Create a version.py module instead of __version__

### DIFF
--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -1,16 +1,8 @@
-"""
-The public API.
-"""
-from ._version import get_versions as _get_versions
-
+# pylint: disable=missing-docstring
 # Import functions/classes to make the API
+from . import version
 from .core import Pooch, create
 from .utils import os_cache, file_hash
-
-
-# Get the version number through versioneer
-__version__ = _get_versions()["version"]
-__commit__ = _get_versions()["full-revisionid"]
 
 
 def test(doctest=True, verbose=True, coverage=False):

--- a/pooch/tests/test_integration.py
+++ b/pooch/tests/test_integration.py
@@ -9,7 +9,8 @@ import warnings
 
 import pytest
 
-from .. import create, os_cache, __version__
+from .. import create, os_cache
+from ..version import full_version
 from .utils import check_tiny_data
 
 
@@ -19,7 +20,7 @@ def pup():
     gar = create(
         path=os_cache("pooch"),
         base_url="https://github.com/fatiando/pooch/raw/{version}/data/",
-        version=__version__,
+        version=full_version,
         version_dev="master",
         env="POOCH_DATA_DIR",
     )

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -3,7 +3,7 @@ Utilities for testing code.
 """
 import os
 
-from .. import __version__
+from ..version import full_version
 from ..utils import check_version
 
 
@@ -26,7 +26,7 @@ def pooch_test_url():
 
     The URL is a github raw link to the ``pooch/tests/data`` directory from the
     `Github repository <https://github.com/fatiando/pooch>`__. It matches the pooch
-    version specified in ``pooch.__version__``.
+    version specified in ``pooch.version.full_version``.
 
     Returns
     -------
@@ -35,7 +35,7 @@ def pooch_test_url():
 
     """
     url = "https://github.com/fatiando/pooch/raw/{version}/pooch/tests/data/".format(
-        version=check_version(__version__)
+        version=check_version(full_version)
     )
     return url
 

--- a/pooch/version.py
+++ b/pooch/version.py
@@ -1,0 +1,9 @@
+# pylint: disable=invalid-name
+"""
+Get the version number and git commit hash from versioneer.
+"""
+from ._version import get_versions
+
+
+full_version = get_versions()["version"]
+git_revision = get_versions()["full-revisionid"]


### PR DESCRIPTION
The dunder name wasn't good form in Python. Replace it with a
`pooch/version.py` module that defines `full_version` and
`git_revision`.