### PR TITLE
Add changelog, warning for py 2.7, and pooch users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ env:
         - COVERAGE=false
         - BUILD_DOCS=false
         - CHECK_FORMAT=false
-        - LINKCHECK=false
         - DEPLOY_DOCS=false
         - DEPLOY_PYPI=false
 
@@ -42,7 +41,6 @@ matrix:
               - CHECK_FORMAT=true
               - COVERAGE=true
               - BUILD_DOCS=true
-              - LINKCHECK=true
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
         - os: linux
@@ -96,9 +94,6 @@ script:
           make test;
       fi
     # Build the documentation
-    - if [ "$LINKCHECK" == "true" ]; then
-          make -C doc linkcheck;
-      fi
     - if [ "$BUILD_DOCS" == "true" ]; then
           make -C doc clean all;
       fi

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,7 +1,8 @@
-# Project Contributors
+# Project Authors
 
 This project was initially created by [Leonardo Uieda](http://www.leouieda.com/).
 
-The following people have made contributions to the project:
+The following people have contributed to the project:
 
 * [Leonardo Uieda](http://www.leouieda.com/)
+* [John Leeman](https://github.com/jrleeman)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Leonardo Uieda
+Copyright (c) 2018 The Pooch Developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -9,7 +9,7 @@ are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
-* Neither the name of Leonardo Uieda nor the names of any contributors
+* Neither the name of the copyright holders nor the names of any contributors
   may be used to endorse or promote products derived from this software
   without specific prior written permission.
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -81,8 +81,9 @@ There are a few steps that still must be done manually, though.
 2. Edit the changes list to remove any trivial changes (updates to the README, typo
    fixes, CI configuration, etc).
 3. Replace the PR number in the commit titles with a link to the Github PR page.
-4. Copy the remaining changes to `doc/changelog.rst` under a new section for the
+4. Copy the remaining changes to `doc/changes.rst` under a new section for the
    intended release.
+5. Add a link to the new release version documentation in `doc/index.rst`.
 5. Open a new PR with the updated changelog.
 
 ### Pushing to PyPI and updating the documentation

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,11 @@ Pooch
     A friend to fetch your sample data files.
 
 `Documentation <http://www.fatiando.org/pooch>`__ |
+`Documentation (dev version) <http://www.fatiando.org/pooch/dev>`__ |
 `Contact <https://gitter.im/fatiando/fatiando>`__ |
 Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 
+🚨 **Python 2.7 will only be supported until the Fall of 2019.** 🚨
 
 .. image:: http://img.shields.io/pypi/v/pooch.svg?style=flat-square
     :alt: Latest version on PyPI
@@ -101,6 +103,15 @@ them in a local directory:
   file.
 * If the hash still doesn't match, Pooch will raise an exception warning of possible
   data corruption.
+
+
+Projects using Pooch
+--------------------
+
+* `MetPy <https://github.com/Unidata/MetPy>`__
+* `Verde <https://github.com/fatiando/verde>`__
+
+*If you're using Pooch, send us a pull request adding your project to the list.*
 
 
 Contacting Us

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -9,9 +9,9 @@
 
 {% block htmltitle %}
     {% if title == '' or title == 'Home' %}
-        <title>{{ docstitle|e }}</title>
+        <title>{{ docstitle|e }} {{ version }}</title>
     {% else %}
-        <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
+    <title>{{ title|striptags|e }}{{ titlesuffix }} {{ version }}</title>
     {% endif %}
 {% endblock %}
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -1,0 +1,25 @@
+.. _changes:
+
+Changelog
+=========
+
+Version 0.1.1 (2018-08-30)
+--------------------------
+
+**Bug fixes:**
+
+* Check if the local data folder is writable and warn the user instead of crashing
+  (`#23 <https://github.com/fatiando/pooch/pull/23>`__)
+
+Version 0.1 (2018-08-20)
+------------------------
+
+* Fist release of Pooch. Manages downloading sample data files over HTTP from a server
+  and storing them in a local directory. Main features:
+
+  - Download a file only if it's not in the local storage.
+  - Check the SHA256 hash to make sure the file is not corrupted or needs updating.
+  - If the hash is different from the registry, Pooch will download a new version of
+    the file.
+  - If the hash still doesn't match, Pooch will raise an exception warning of possible
+    data corruption.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 # General information about the project
 year = datetime.date.today().year
 project = 'Pooch'
-copyright = '2018-{}, Leonardo Uieda'.format(year)
+copyright = '2018-{}, The Pooch Developers'.format(year)
 if len(full_version.split('+')) > 1 or full_version == 'unknown':
     version = 'dev'
 else:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,6 +3,16 @@
 .. include:: ../README.rst
 
 
+Documentation for other versions
+--------------------------------
+
+* `Development <http://www.fatiando.org/pooch/dev>`__ (reflects the *master* branch on
+  Github)
+* `Latest release <http://www.fatiando.org/pooch/latest>`__
+* `v0.1.1 <http://www.fatiando.org/pooch/v0.1.1>`__
+* `v0.1 <http://www.fatiando.org/pooch/v0.1>`__
+
+
 .. toctree::
     :maxdepth: 2
     :hidden:
@@ -11,3 +21,5 @@
     install.rst
     usage.rst
     api/index.rst
+    changes.rst
+

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -8,6 +8,12 @@ Which Python?
 
 You'll need Python 2.7 or **Python >=3.5 (recommended)**.
 
+.. warning::
+
+   🚨 **Python 2.7 will only be supported until the Fall of 2019.** 🚨
+
+   Relases made after this date will only be compatible with Python 3.
+
 We recommend using the
 `Anaconda Python distribution <https://www.anaconda.com/download>`__
 to ensure you have all dependencies installed and the ``conda`` package manager

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -140,7 +140,7 @@ def create(path, base_url, version, version_dev, env=None, registry=None):
     except PermissionError:
         message = (
             "Cannot write to data cache '{}'. "
-            "Will not be able to download remote data files.".format(versioned_path)
+            "Will not be able to download remote data files. ".format(versioned_path)
         )
         if env is not None:
             message = (


### PR DESCRIPTION
Chagelog includes the future 0.1.1 bug fix release (#23).
Python 2.7 will only be supported until MetPy drops support (fall of
2019).
List projects using Pooch (fixes #21).
