### PR TITLE
Add testing and support for Python 3.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,19 +10,23 @@ branches:
 
 environment:
     matrix:
-        - MINICONDA: C:\Miniconda-x64
-          PYTHON: 2.7
-          CONDA_REQUIREMENTS: requirements27.txt
-        - MINICONDA: C:\Miniconda35-x64
-          PYTHON: 3.5
+        - MINICONDA: C:\Miniconda36-x64
+          PYTHON: 3.7
           CONDA_REQUIREMENTS: requirements.txt
         - MINICONDA: C:\Miniconda36-x64
           PYTHON: 3.6
           CONDA_REQUIREMENTS: requirements.txt
+        - MINICONDA: C:\Miniconda35-x64
+          PYTHON: 3.5
+          CONDA_REQUIREMENTS: requirements.txt
+        - MINICONDA: C:\Miniconda-x64
+          PYTHON: 2.7
+          CONDA_REQUIREMENTS: requirements27.txt
 
 init:
     # Add miniconda to the PATH
     - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"
+    - set CONDA_REQUIREMENTS_DEV=requirements-dev.txt
 
 install:
     # Get the Fatiando CI scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
         - TWINE_USERNAME=Leonardo.Uieda
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
+        - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
         # These variables control which actions are performed in a build
         - COVERAGE=false
         - BUILD_DOCS=false
@@ -37,12 +38,18 @@ matrix:
     include:
         - os: linux
           env:
+              - PYTHON=3.7
+              - BUILD_DOCS=true
+        - os: linux
+          env:
               - PYTHON=3.6
               - CHECK_FORMAT=true
               - COVERAGE=true
               - BUILD_DOCS=true
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
+              # Black is Python 3.6 only so it can't be in the requirements file.
+              - CONDA_INSTALL_EXTRA="black"
         - os: linux
           env:
               - PYTHON=3.5
@@ -52,6 +59,10 @@ matrix:
               - PYTHON=2.7
               - COVERAGE=true
               - CONDA_REQUIREMENTS=requirements27.txt
+        - os: osx
+          env:
+              - PYTHON=3.7
+              - BUILD_DOCS=true
         - os: osx
           env:
               - PYTHON=3.6
@@ -81,9 +92,7 @@ install:
 # Run the actual tests and checks
 script:
     # Check code for style and quality
-    # Black is Python 3.6 only so it can't be in the requirements file.
     - if [ "$CHECK_FORMAT" == "true" ]; then
-          conda install --yes --channel conda-forge black python=$PYTHON;
           make check;
       fi
     # Run the test suite

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -83,7 +83,7 @@ There are a few steps that still must be done manually, though.
 3. Replace the PR number in the commit titles with a link to the Github PR page.
 4. Copy the remaining changes to `doc/changes.rst` under a new section for the
    intended release.
-5. Add a link to the new release version documentation in `doc/index.rst`.
+5. Add a link to the new release version documentation in `README.rst`.
 5. Open a new PR with the updated changelog.
 
 ### Pushing to PyPI and updating the documentation

--- a/README.rst
+++ b/README.rst
@@ -176,3 +176,13 @@ License
 This is free software: you can redistribute it and/or modify it under the terms
 of the **BSD 3-clause License**. A copy of this license is provided in
 `LICENSE.txt <https://github.com/fatiando/pooch/blob/master/LICENSE.txt>`__.
+
+
+Documentation for other versions
+--------------------------------
+
+* `Development <http://www.fatiando.org/pooch/dev>`__ (reflects the *master* branch on
+  Github)
+* `Latest release <http://www.fatiando.org/pooch/latest>`__
+* `v0.1.1 <http://www.fatiando.org/pooch/v0.1.1>`__
+* `v0.1 <http://www.fatiando.org/pooch/v0.1>`__

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,17 +2,6 @@
 
 .. include:: ../README.rst
 
-
-Documentation for other versions
---------------------------------
-
-* `Development <http://www.fatiando.org/pooch/dev>`__ (reflects the *master* branch on
-  Github)
-* `Latest release <http://www.fatiando.org/pooch/latest>`__
-* `v0.1.1 <http://www.fatiando.org/pooch/v0.1.1>`__
-* `v0.1 <http://www.fatiando.org/pooch/v0.1>`__
-
-
 .. toctree::
     :maxdepth: 2
     :hidden:

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,3 @@ dependencies:
     - sphinx
     - sphinx_rtd_theme
     - numpydoc
-    - twine

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Development requirements
+pytest
+pytest-cov
+coverage
+pylint
+sphinx
+sphinx_rtd_theme
+numpydoc
+twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,2 @@
 requests
 packaging
-# Development requirements
-pytest
-pytest-cov
-coverage
-pylint
-sphinx
-sphinx_rtd_theme
-numpydoc
-twine
-# Black is not included because it requires Python 3.6
-#black

--- a/requirements27.txt
+++ b/requirements27.txt
@@ -1,8 +1,5 @@
+# Requirements for Python 2.7
 requests
 packaging
 backports.tempfile
 pathlib
-# Development requirements
-pytest
-pytest-cov
-coverage

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open("README.rst") as f:
 VERSION = versioneer.get_version()
 CMDCLASS = versioneer.get_cmdclass()
 CLASSIFIERS = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
@@ -38,6 +38,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "License :: OSI Approved :: {}".format(LICENSE),
 ]
 PLATFORMS = "Any"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open("README.rst") as f:
 VERSION = versioneer.get_version()
 CMDCLASS = versioneer.get_cmdclass()
 CLASSIFIERS = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "Intended Audience :: Education",


### PR DESCRIPTION
Enables the CIs to run tests in 3.7 but keep 3.6 as the main deployment
environment for now. 