### PR TITLE
Avoid copies across filesystem

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -299,7 +299,7 @@ class Pooch:
         source = self._get_url(fname)
         # Stream the file to a temporary so that we can safely check its hash before
         # overwriting the original
-        fout = tempfile.NamedTemporaryFile(delete=False)
+        fout = tempfile.NamedTemporaryFile(delete=False, dir=self.abspath)
         try:
             with fout:
                 response = requests.get(source, stream=True)

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -299,7 +299,7 @@ class Pooch:
         source = self._get_url(fname)
         # Stream the file to a temporary so that we can safely check its hash before
         # overwriting the original
-        fout = tempfile.NamedTemporaryFile(delete=False, dir=self.abspath)
+        fout = tempfile.NamedTemporaryFile(delete=False, dir=str(self.abspath))
         try:
             with fout:
                 response = requests.get(source, stream=True)


### PR DESCRIPTION
If the temporary directory is a separate filesystem (often the case), the `shutil.move()` call will actually need to copy the file contents, rather than being an O(1) operation.

Creating the file in the destination folder avoids this issue.