### PR TITLE
Fix unwanted ~ directory creation

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -152,8 +152,9 @@ def create(
         path = os.environ[env]
     if version is not None:
         version = check_version(version, fallback=version_dev)
-        path = os.path.join(os.path.expanduser(str(path)), version)
+        path = os.path.join(path, version)
         base_url = base_url.format(version=version)
+    path = os.path.expanduser(str(path))
     # Check that the data directory is writable
     try:
         if not os.path.exists(path):


### PR DESCRIPTION
The unwanted directory creation was due to `path` string including
the user's home directory shortcut '~'.
The home directory shortcut is now replaced by the absolute path
(`/home/<user>/`) even if `version` argument is None.

Fixes #36 
