### PR TITLE
Fix typo on Pooch.load_registry docstring

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -327,7 +327,7 @@ class Pooch:
 
     def load_registry(self, fname):
         """
-        Load entries form a file and add them to the registry.
+        Load entries from a file and add them to the registry.
 
         Use this if you are managing many files.
 


### PR DESCRIPTION
Fix typo in the docstring of `load_registry` method of `Pooch` class.

Fixes #40 