### PR TITLE
Add registry_files property to Pooch

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -95,6 +95,8 @@ def create(
     http://some.link.com/v0.1/
     >>> print(pup.registry)
     {'data.txt': '9081wo2eb2gc0u...'}
+    >>> print(pup.registry_files)
+    ['data.txt']
 
     If this is a development version (12 commits ahead of v0.1), then the
     ``version_dev`` will be used (defaults to ``"master"``):
@@ -217,6 +219,11 @@ class Pooch:
     def abspath(self):
         "Absolute path to the local storage"
         return Path(os.path.abspath(os.path.expanduser(str(self.path))))
+
+    @property
+    def registry_files(self):
+        "List of file names on the registry"
+        return list(self.registry)
 
     def fetch(self, fname):
         """

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -121,6 +121,7 @@ def test_pooch_load_registry():
     pup = Pooch(path="", base_url="")
     pup.load_registry(os.path.join(DATA_DIR, "registry.txt"))
     assert pup.registry == REGISTRY
+    assert pup.registry_files.sort() == list(REGISTRY).sort()
 
 
 def test_pooch_load_registry_custom_url():


### PR DESCRIPTION
This property returns a list of the file names inside the registry.
This makes the access to the names of the files inside the registry easier, without having to convert the dictionary keys into a list.
