### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,9 +16,6 @@ environment:
         - MINICONDA: C:\Miniconda36-x64
           PYTHON: 3.6
           CONDA_REQUIREMENTS: requirements.txt
-        - MINICONDA: C:\Miniconda35-x64
-          PYTHON: 3.5
-          CONDA_REQUIREMENTS: requirements.txt
         # Downgrade pip on 2.7 to avoid failures from a deprecation warning
         - MINICONDA: C:\Miniconda-x64
           PYTHON: 2.7

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -86,9 +86,6 @@ jobs:
       Python36:
         python.version: '3.6'
         PYTHON: '3.6'
-      Python35:
-        python.version: '3.5'
-        PYTHON: '3.5'
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'
@@ -170,9 +167,6 @@ jobs:
       Python36:
         python.version: '3.6'
         PYTHON: '3.6'
-      Python35:
-        python.version: '3.5'
-        PYTHON: '3.5'
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,6 @@ matrix:
               - PYTHON=3.6
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
-        - name: "Linux - Python 3.5"
-          os: linux
-          env:
-              - PYTHON=3.5
         - name: "Linux - Python 2.7"
           os: linux
           env:

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,7 +6,7 @@ Installing
 Which Python?
 -------------
 
-You'll need Python 2.7 or **Python >=3.5 (recommended)**.
+You'll need Python 2.7 or **Python >=3.6 (recommended)**.
 
 .. warning::
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ CLASSIFIERS = [
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "License :: OSI Approved :: {}".format(LICENSE),
@@ -57,7 +56,7 @@ INSTALL_REQUIRES = [
     "pathlib;python_version<'3.5'",
     "backports.tempfile;python_version<'3.5'",
 ]
-PYTHON_REQUIRES = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+PYTHON_REQUIRES = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 if __name__ == "__main__":
     setup(


### PR DESCRIPTION
We'll no longer build packages or test in 3.5.
Update the required python version in setup.py
to avoid pip installing a broken version.

Fixes #47


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
