### PR TITLE
Make Pooch.get_url public

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -17,5 +17,6 @@ API Reference
     Pooch
     Pooch.fetch
     Pooch.is_available
+    Pooch.get_url
     Pooch.load_registry
     test

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -263,7 +263,7 @@ class Pooch:
         if action in ("Updating", "Downloading"):
             warn(
                 "{} data file '{}' from remote data store '{}' to '{}'.".format(
-                    action, fname, self.base_url, str(self.path)
+                    action, fname, self.get_url(fname), str(self.path)
                 )
             )
             self._download_file(fname)
@@ -276,11 +276,9 @@ class Pooch:
         if fname not in self.registry:
             raise ValueError("File '{}' is not in the registry.".format(fname))
 
-    def _get_url(self, fname):
+    def get_url(self, fname):
         """
-        Compute the full URL to a file.
-
-        Provided for easy override in subclasses.
+        Get the full URL to download a file in the registry.
 
         Parameters
         ----------
@@ -289,6 +287,7 @@ class Pooch:
             fetch from the local storage.
 
         """
+        self._assert_file_in_registry(fname)
         return self.urls.get(fname, "".join([self.base_url, fname]))
 
     def _download_file(self, fname):
@@ -310,7 +309,7 @@ class Pooch:
 
         """
         destination = self.abspath / fname
-        source = self._get_url(fname)
+        source = self.get_url(fname)
         # Stream the file to a temporary so that we can safely check its hash before
         # overwriting the original
         fout = tempfile.NamedTemporaryFile(delete=False, dir=str(self.abspath))
@@ -390,6 +389,6 @@ class Pooch:
 
         """
         self._assert_file_in_registry(fname)
-        source = self._get_url(fname)
+        source = self.get_url(fname)
         response = requests.head(source, allow_redirects=True)
         return bool(response.status_code == 200)


### PR DESCRIPTION
No reason for this to be private and could be useful for libraries
using or extending Pooch.
Fix download warning with wrong URL when using custom URLs.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
