### PR TITLE
Fix typo in create docstring

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -31,7 +31,7 @@ def create(
     Create a new :class:`~pooch.Pooch` with sensible defaults to fetch data files.
 
     If a version string is given, the Pooch will be versioned, meaning that the local
-    storage folder and the base URL depend on the projection version. This is necessary
+    storage folder and the base URL depend on the project version. This is necessary
     if your users have multiple versions of your library installed (using virtual
     environments) and you updated the data files between versions. Otherwise, every time
     a user switches environments would trigger a re-download of the data. The version


### PR DESCRIPTION
Fixes #60



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
