### PR TITLE
Pin sphinx to version 1.8.5

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,6 @@ dependencies:
     - black
     - flake8
     - pylint
-    - sphinx
+    - sphinx=1.8.5
     - sphinx_rtd_theme
     - numpydoc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest-cov
 coverage
 pylint
 flake8
-sphinx
+sphinx=1.8.5
 sphinx_rtd_theme
 numpydoc
 twine


### PR DESCRIPTION
New versions of Sphinx (`2.0.0`, `2.0.1`) create unexpected wrong format on docstrings.
A momentarily solution is to pin Sphinx to the last version before `2.0.0`: `1.8.5`.
We should go back to the latest Sphinx release when this bug is fixed on their
repository.

This issue was raised on fatiando/harmonica#58.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
