### PR TITLE
Make the check_version public

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -14,6 +14,7 @@ API Reference
     os_cache
     file_hash
     make_registry
+    check_version
     Pooch
     Pooch.fetch
     Pooch.is_available

--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -2,7 +2,7 @@
 # Import functions/classes to make the API
 from . import version
 from .core import Pooch, create
-from .utils import os_cache, file_hash, make_registry
+from .utils import os_cache, file_hash, make_registry, check_version
 
 
 def test(doctest=True, verbose=True, coverage=False):


### PR DESCRIPTION
It's used internally but will be useful in examples and doctests that
want to download things from the pooch repository (with a specific
version instead of getting from master all the time).

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
