### PR TITLE
Add back the API entry for Pooch methods

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -14,6 +14,10 @@ Core:
 
     create
     Pooch
+    Pooch.fetch
+    Pooch.load_registry
+    Pooch.get_url
+    Pooch.is_available
 
 Utilities:
 


### PR DESCRIPTION
Removed by mistake so the pages weren't being generated.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
