### PR TITLE
Fix itemization in Decompress docstring

### DIFF
--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -242,9 +242,11 @@ class Decompress:  # pylint: disable=too-few-public-methods
             Full path of the compressed file in local storage.
         action : str
             Indicates what action was taken by :meth:`pooch.Pooch.fetch`. One of:
-            * ``"download"``: The file didn't exist locally and was downloaded
-            * ``"update"``: The local file was outdated and was re-download
-            * ``"fetch"``: The file exists and is updated so it wasn't downloaded
+
+            - ``"download"``: The file didn't exist locally and was downloaded
+            - ``"update"``: The local file was outdated and was re-download
+            - ``"fetch"``: The file exists and is updated so it wasn't downloaded
+
         pooch : :class:`pooch.Pooch`
             The instance of :class:`pooch.Pooch` that is calling this.
 


### PR DESCRIPTION
Improve the itemization of possible values for `action` parameter in `Decompress` class.


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
