### PR TITLE
Fix wrong imports in Training Your Pooch docs

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -267,7 +267,7 @@ Pooch processor would look like:
 
 .. code:: python
 
-    from pooch import UnzipSingle
+    from pooch import Unzip
 
 
     def fetch_zipped_file():
@@ -290,8 +290,6 @@ this case, the default behavior of :class:`pooch.Unzip` is to extract all files 
 directory and return a list of file paths instead of a single one:
 
 .. code:: python
-
-    from pooch import Unzip
 
     def fetch_zipped_archive():
         """


### PR DESCRIPTION
Remove mention of the `UnzipSingle` class which doesn't exist.

Fixes #82




**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.