### PR TITLE
Add back support for Python 3.5 and CI tests

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -86,6 +86,9 @@ jobs:
       Python36:
         python.version: '3.6'
         PYTHON: '3.6'
+      Python35:
+        python.version: '3.5'
+        PYTHON: '3.5'
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'
@@ -168,6 +171,9 @@ jobs:
       Python36:
         python.version: '3.6'
         PYTHON: '3.6'
+      Python35:
+        python.version: '3.5'
+        PYTHON: '3.5'
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -89,7 +89,8 @@ jobs:
       Python35:
         python.version: '3.5'
         PYTHON: '3.5'
-        CONDA_INSTALL_EXTRA: "codecov pip"
+        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx sphinx_rtd_theme numpydoc"
+        CONDA_REQUIREMENTS_DEV: ""
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'
@@ -175,7 +176,8 @@ jobs:
       Python35:
         python.version: '3.5'
         PYTHON: '3.5'
-        CONDA_INSTALL_EXTRA: "codecov pip"
+        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx sphinx_rtd_theme numpydoc"
+        CONDA_REQUIREMENTS_DEV: ""
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -89,6 +89,7 @@ jobs:
       Python35:
         python.version: '3.5'
         PYTHON: '3.5'
+        CONDA_INSTALL_EXTRA: "codecov pip"
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'
@@ -174,6 +175,7 @@ jobs:
       Python35:
         python.version: '3.5'
         PYTHON: '3.5'
+        CONDA_INSTALL_EXTRA: "codecov pip"
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,12 @@ matrix:
               - PYTHON=3.6
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
+              - CONDA_INSTALL_EXTRA="codecov twine"
         - name: "Linux - Python 3.5"
           os: linux
           env:
               - PYTHON=3.5
+              - CONDA_INSTALL_EXTRA="codecov pip"
         - name: "Linux - Python 2.7"
           os: linux
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ matrix:
           os: linux
           env:
               - PYTHON=3.5
-              - CONDA_INSTALL_EXTRA="codecov pip"
+              - CONDA_INSTALL_EXTRA="codecov pip pytest pytest-cov coverage sphinx sphinx_rtd_theme numpydoc"
+              - CONDA_REQUIREMENTS_DEV=""
         - name: "Linux - Python 2.7"
           os: linux
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,10 @@ matrix:
               - PYTHON=3.6
               - DEPLOY_DOCS=true
               - DEPLOY_PYPI=true
+        - name: "Linux - Python 3.5"
+          os: linux
+          env:
+              - PYTHON=3.5
         - name: "Linux - Python 2.7"
           os: linux
           env:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ flake8
 sphinx=1.8.5
 sphinx_rtd_theme
 numpydoc
-twine

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ CLASSIFIERS = [
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "License :: OSI Approved :: {}".format(LICENSE),

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ INSTALL_REQUIRES = [
     "pathlib;python_version<'3.5'",
     "backports.tempfile;python_version<'3.5'",
 ]
-PYTHON_REQUIRES = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+PYTHON_REQUIRES = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 if __name__ == "__main__":
     setup(


### PR DESCRIPTION
Enable CI runs for 3.5 on Travis and Azure to make it works.

Fixes #92


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.