### PR TITLE
Fix pylint error + CI 3.5 builds with sphinx=2.0.0

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -89,7 +89,7 @@ jobs:
       Python35:
         python.version: '3.5'
         PYTHON: '3.5'
-        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx=1.8.5 sphinx_rtd_theme numpydoc"
+        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx=2.0.0 sphinx_rtd_theme numpydoc"
         CONDA_REQUIREMENTS_DEV: ""
       Python27:
         python.version: '2.7'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -89,6 +89,8 @@ jobs:
       Python35:
         python.version: '3.5'
         PYTHON: '3.5'
+        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx=1.8.5 sphinx_rtd_theme numpydoc"
+        CONDA_REQUIREMENTS_DEV: ""
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -100,6 +100,12 @@ jobs:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: Add conda to PATH
 
+  # On Hosted macOS, the agent user doesn't have ownership of Miniconda's installation
+  # directory We need to take ownership if we want to update conda or install packages
+  # globally
+  - bash: sudo chown -R $USER $CONDA
+    displayName: Take ownership of conda installation
+
   # Get the Fatiando CI scripts
   - bash: git clone --branch=1.1.1 --depth=1 https://github.com/fatiando/continuous-integration.git
     displayName: Fetch the Fatiando CI scripts

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -89,8 +89,6 @@ jobs:
       Python35:
         python.version: '3.5'
         PYTHON: '3.5'
-        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx sphinx_rtd_theme numpydoc"
-        CONDA_REQUIREMENTS_DEV: ""
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'
@@ -176,8 +174,6 @@ jobs:
       Python35:
         python.version: '3.5'
         PYTHON: '3.5'
-        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx sphinx_rtd_theme numpydoc"
-        CONDA_REQUIREMENTS_DEV: ""
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -89,6 +89,7 @@ jobs:
       Python35:
         python.version: '3.5'
         PYTHON: '3.5'
+        # Need to use sphinx=2.0.0 because 1.8.5 causes conflicts and 2.2.0 crashes
         CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx=2.0.0 sphinx_rtd_theme numpydoc"
         CONDA_REQUIREMENTS_DEV: ""
       Python27:
@@ -182,6 +183,9 @@ jobs:
       Python35:
         python.version: '3.5'
         PYTHON: '3.5'
+        # Need to use sphinx=2.0.0 because 1.8.5 causes conflicts and 2.2.0 crashes
+        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx=2.0.0 sphinx_rtd_theme numpydoc"
+        CONDA_REQUIREMENTS_DEV: ""
       Python27:
         python.version: '2.7'
         PYTHON: '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,6 @@ matrix:
           os: linux
           env:
               - PYTHON=3.5
-              - CONDA_INSTALL_EXTRA="codecov pip pytest pytest-cov coverage sphinx sphinx_rtd_theme numpydoc"
-              - CONDA_REQUIREMENTS_DEV=""
         - name: "Linux - Python 2.7"
           os: linux
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,9 @@ matrix:
           os: linux
           env:
               - PYTHON=3.5
+              # Need to use sphinx=2.0.0 because 1.8.5 causes conflicts and 2.2.0 crashes
+              - CONDA_INSTALL_EXTRA="codecov pip pytest pytest-cov coverage sphinx=2.0.0 sphinx_rtd_theme numpydoc"
+              - CONDA_REQUIREMENTS_DEV=""
         - name: "Linux - Python 2.7"
           os: linux
           env:

--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,import-outside-toplevel
 # Import functions/classes to make the API
 from . import version
 from .core import Pooch, create

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,6 @@
 pytest
 pytest-cov
 coverage
-pylint
-flake8
 sphinx=1.8.5
 sphinx_rtd_theme
 numpydoc


### PR DESCRIPTION
Python 3.5 builds were crashing with sphinx 2.2.0 and have dependency problems with 1.8.5. Using 2.0.0 seems to fix this problem. It's fine because we don't deploy these docs anyway.
Pylint 2.4.2 raises error for import inside the `test` function in `pooch/__init__.py`. Disable warning for this file only.

**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
