### PR TITLE
Warn that 0.6.0 is the last to support Python 2.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,8 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 .. placeholder-for-doc-index
 
 
-🚨🚨 **Python 2.7 will only be supported until the Fall of 2019.** 🚨🚨
+🚨🚨 **Pooch v0.6.0 is the last release to support Python 2.7. Please update to Python 3
+or use Pooch <= 0.6.0.** 🚨🚨
 
 
 TL;DR

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,13 +6,12 @@ Installing
 Which Python?
 -------------
 
-You'll need Python 2.7 or **Python >=3.6 (recommended)**.
+You'll need Python 2.7 or **Python >=3.5 (recommended)**.
 
 .. warning::
 
-   🚨 **Python 2.7 will only be supported until the Fall of 2019.** 🚨
-
-   Relases made after this date will only be compatible with Python 3.
+    🚨 **Pooch v0.6.0 is the last release to support Python 2.7. Please update to Python
+    3 or use Pooch <= 0.6.0.** 🚨
 
 We recommend using the
 `Anaconda Python distribution <https://www.anaconda.com/download>`__


### PR DESCRIPTION
Edit the warning in README and install page to say that 0.6.0 is the
last to support Python 2.7. Ask people to upgrade or pin pooch to <=
0.6.

Related to #105



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
