### PR TITLE
Some tweaks to Py2.7 warning and date of release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,7 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 .. placeholder-for-doc-index
 
 
-🚨🚨 **Pooch v0.6.0 is the last release to support Python 2.7. Please update to Python 3
-or use Pooch <= 0.6.0.** 🚨🚨
+🚨🚨 **Pooch v0.6.0 is the last release to support Python 2.7** 🚨🚨
 
 
 TL;DR

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,11 +6,13 @@ Changelog
 Version 0.6.0
 -------------
 
-*Released on: 2019/10/21*
+*Released on: 2019/10/22*
 
 .. image:: https://img.shields.io/badge/doi-10.5281%2Fzenodo.3515031-blue.svg?style=flat-square
     :alt: Digital Object Identifier for the Zenodo archive
     :target: https://doi.org/10.5281/zenodo.3515031
+
+🚨 **Pooch v0.6.0 is the last release to support Python 2.7** 🚨
 
 New features:
 


### PR DESCRIPTION
The changelog has yesterday's date as the release date. Also add the 2.7
warning to the changelog for extra visibility.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
