### PR TITLE
Using logging API instead of warnings

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -26,6 +26,7 @@ Utilities
     make_registry
     file_hash
     check_version
+    get_logger
 
 Downloaders
 -----------

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -493,6 +493,24 @@ this:
     ``tqdm`` is not installed by default with Pooch. You will have to install it
     separately in order to use this feature.
 
+
+Adjusting the logging level
+---------------------------
+
+Pooch will log events like downloading a new file, updating an existing one, or
+unpacking an archive by printing to the terminal. You can change how verbose these
+events are by getting the event logger from pooch and changing the logging level:
+
+.. code:: python
+
+    logger = pooch.get_logger()
+    logger.setLevel("WARNING")
+
+Most of the events from Pooch are logged at the info level; this code says that you only
+care about warnings or errors, like inability to create the data cache. The event logger
+is a :class:`logging.Logger` object, so you can use that class's methods to handle
+logging events in more sophisticated ways if you wish.
+
 So you have 1000 data files
 ---------------------------
 

--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -2,7 +2,7 @@
 # Import functions/classes to make the API
 from . import version
 from .core import Pooch, create
-from .utils import os_cache, file_hash, make_registry, check_version
+from .utils import os_cache, file_hash, make_registry, check_version, get_logger
 from .downloaders import HTTPDownloader, FTPDownloader
 from .processors import Unzip, Untar, Decompress
 

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -10,7 +10,7 @@ from warnings import warn
 import ftplib
 
 import requests
-from .utils import file_hash, check_version, parse_url
+from .utils import file_hash, check_version, parse_url, get_logger
 from .downloaders import HTTPDownloader, FTPDownloader
 
 KNOWN_DOWNLOADERS = {
@@ -374,10 +374,20 @@ class Pooch:
 
         if action in ("download", "update"):
             action_word = dict(download="Downloading", update="Updating")
+
+            # Remove this if we switch to logging instead of warnings.
             warn(
                 "{} data file '{}' from remote data store '{}' to '{}'.".format(
                     action_word[action], fname, self.get_url(fname), str(self.path)
                 )
+            )
+
+            get_logger().info(
+                "%s data file '%s' from remote data store '%s' to '%s'.",
+                action_word[action],
+                fname,
+                self.get_url(fname),
+                str(self.path),
             )
 
             parsed_url = parse_url(url)

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 import shutil
 import tempfile
-from warnings import warn
 import ftplib
 
 import requests
@@ -172,17 +171,15 @@ def create(
             tempfile.NamedTemporaryFile(dir=path)
     except PermissionError:
         message = (
-            "Cannot write to data cache '{}'. "
-            "Will not be able to download remote data files. ".format(path)
+            "Cannot write to data cache '%s'. "
+            "Will not be able to download remote data files. "
         )
+        args = [path]
         if env is not None:
-            message = (
-                message
-                + "Use environment variable '{}' to specify another directory.".format(
-                    env
-                )
-            )
-        warn(message)
+            message += "Use environment variable '%s' to specify another directory."
+            args += [env]
+
+        get_logger().warning(message, *args)
     pup = Pooch(path=Path(path), base_url=base_url, registry=registry, urls=urls)
     return pup
 
@@ -374,14 +371,6 @@ class Pooch:
 
         if action in ("download", "update"):
             action_word = dict(download="Downloading", update="Updating")
-
-            # Remove this if we switch to logging instead of warnings.
-            warn(
-                "{} data file '{}' from remote data store '{}' to '{}'.".format(
-                    action_word[action], fname, self.get_url(fname), str(self.path)
-                )
-            )
-
             get_logger().info(
                 "%s data file '%s' from remote data store '%s' to '%s'.",
                 action_word[action],

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -9,7 +9,8 @@ import lzma
 import shutil
 from zipfile import ZipFile
 from tarfile import TarFile
-from warnings import warn
+
+from .utils import get_logger
 
 
 class ExtractorProcessor:  # pylint: disable=too-few-public-methods
@@ -115,15 +116,15 @@ class Unzip(ExtractorProcessor):  # pylint: disable=too-few-public-methods
         """
         with ZipFile(fname, "r") as zip_file:
             if self.members is None:
-                warn("Unzipping contents of '{}' to '{}'".format(fname, extract_dir))
+                get_logger().info(
+                    "Unzipping contents of '%s' to '%s'", fname, extract_dir
+                )
                 # Unpack all files from the archive into our new folder
                 zip_file.extractall(path=extract_dir)
             else:
                 for member in self.members:
-                    warn(
-                        "Extracting '{}' from '{}' to '{}'".format(
-                            member, fname, extract_dir
-                        )
+                    get_logger().info(
+                        "Extracting '%s' from '%s' to '%s'", member, fname, extract_dir
                     )
                     # Extract the data file from within the archive
                     with zip_file.open(member) as data_file:
@@ -160,15 +161,15 @@ class Untar(ExtractorProcessor):  # pylint: disable=too-few-public-methods
         """
         with TarFile.open(fname, "r") as tar_file:
             if self.members is None:
-                warn("Untarring contents of '{}' to '{}'".format(fname, extract_dir))
+                get_logger().info(
+                    "Untarring contents of '%s' to '%s'", fname, extract_dir
+                )
                 # Unpack all files from the archive into our new folder
                 tar_file.extractall(path=extract_dir)
             else:
                 for member in self.members:
-                    warn(
-                        "Extracting '{}' from '{}' to '{}'".format(
-                            member, fname, extract_dir
-                        )
+                    get_logger().info(
+                        "Extracting '%s' from '%s' to '%s'", member, fname, extract_dir
                     )
                     # Extract the data file from within the archive
                     # Python 2.7: extractfile doesn't return a context manager
@@ -238,10 +239,11 @@ class Decompress:  # pylint: disable=too-few-public-methods
         """
         decompressed = fname + ".decomp"
         if action in ("update", "download") or not os.path.exists(decompressed):
-            warn(
-                "Decompressing '{}' to '{}' using method '{}'.".format(
-                    fname, decompressed, self.method
-                )
+            get_logger().info(
+                "Decompressing '%s' to '%s' using method '%s'.",
+                fname,
+                decompressed,
+                self.method,
             )
             module = self._compression_module(fname)
             with open(decompressed, "w+b") as output:

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -6,8 +6,6 @@ import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import tempfile
-from io import StringIO
-from logging import StreamHandler
 
 import pytest
 
@@ -94,26 +92,15 @@ def test_pooch_download():
 def test_pooch_logging_level():
     "Setup a pooch and check that no logging happens when the level is raised"
     with TemporaryDirectory() as local_store:
-        # Add a new handler for critical events only
-        critical_log_file = StringIO()
-        critical_handler = StreamHandler(critical_log_file)
-        critical_handler.setLevel("CRITICAL")
-        get_logger().addHandler(critical_handler)
         path = Path(local_store)
         urls = {"tiny-data.txt": BASEURL + "tiny-data.txt"}
         # Setup a pooch in a temp dir
         pup = Pooch(path=path, base_url="", registry=REGISTRY, urls=urls)
-        # Check that the logs say that the file is being downloaded
-        with capture_log() as log_file:
+        # Capture only critical logging events
+        with capture_log("CRITICAL") as log_file:
             fname = pup.fetch("tiny-data.txt")
-            logs = log_file.getvalue()
-            assert logs.split()[0] == "Downloading"
-            assert logs.split()[-1] == "'{}'.".format(path)
+            assert log_file.getvalue() == ""
         check_tiny_data(fname)
-        # Check that the logs for critical errors are empty
-        critical_logs = critical_log_file.getvalue()
-        assert critical_logs == ""
-        get_logger().removeHandler(critical_handler)
 
 
 def test_pooch_update():

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -2,9 +2,12 @@
 Utilities for testing code.
 """
 import os
+import io
+import logging
+from contextlib import contextmanager
 
 from ..version import full_version
-from ..utils import check_version
+from ..utils import check_version, get_logger
 
 
 def check_tiny_data(fname):
@@ -75,3 +78,20 @@ def pooch_test_registry():
         "tiny-data.txt.xz": "99dcb5c32a6e916344bacb4badcbc2f2b6ee196977d1d8187610c21e7e607765",
     }
     return registry
+
+
+@contextmanager
+def capture_log():
+    """
+    Create a context manager for reading from the logs.
+
+    Yields
+    ------
+    log_file : StringIO
+        a file-like object to which the logs were written
+    """
+    log_file = io.StringIO()
+    handler = logging.StreamHandler(log_file)
+    get_logger().addHandler(handler)
+    yield log_file
+    get_logger().removeHandler(handler)

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -81,7 +81,7 @@ def pooch_test_registry():
 
 
 @contextmanager
-def capture_log():
+def capture_log(level=logging.DEBUG):
     """
     Create a context manager for reading from the logs.
 
@@ -92,6 +92,7 @@ def capture_log():
     """
     log_file = io.StringIO()
     handler = logging.StreamHandler(log_file)
+    handler.setLevel(level)
     get_logger().addHandler(handler)
     yield log_file
     get_logger().removeHandler(handler)

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -1,11 +1,21 @@
 """
 Misc utilities
 """
+import logging
 from pathlib import Path
 import hashlib
 from urllib.parse import urlsplit
 import appdirs
 from packaging.version import Version
+
+
+LOGGER = logging.Logger("pooch")
+LOGGER.addHandler(logging.StreamHandler())
+
+
+def get_logger():
+    r"""Return the object that logs events from pooch"""
+    return LOGGER
 
 
 def os_cache(project):

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -14,7 +14,18 @@ LOGGER.addHandler(logging.StreamHandler())
 
 
 def get_logger():
-    r"""Return the object that logs events from pooch"""
+    r"""
+    Get the default event logger.
+
+    The logger records events like downloading files, unzipping archives, etc.
+    Use the method :meth:`logging.Logger.setLevel` of this object to adjust the
+    verbosity level from Pooch.
+
+    Returns
+    -------
+    logger : :class:`logging.Logger`
+        The logger object for Pooch
+    """
     return LOGGER
 
 


### PR DESCRIPTION
This patch replaces the use of warnings to give feedback to the user
with the logging functionality from the Python standard library. Using
the logging API means that messages can be logged with different
priorities and the user can select which priority they want to see.
Fixes #114 .

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
