### PR TITLE
Add support for file objects to load_registry()

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -442,7 +442,7 @@ class Pooch:
         Parameters
         ----------
         fname : str | fileobj
-            File path to the registry file, of file object.
+            Path (or open file object) to the registry file.
 
         """
         with contextlib.ExitStack() as stack:

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -159,6 +159,25 @@ def test_pooch_load_registry():
     assert pup.registry_files.sort() == list(REGISTRY).sort()
 
 
+def test_pooch_load_registry_fileobj():
+    "Loading the registry from a file object"
+    path = os.path.join(DATA_DIR, "registry.txt")
+
+    # Binary mode
+    pup = Pooch(path="", base_url="")
+    with open(path, "rb") as fin:
+        pup.load_registry(fin)
+    assert pup.registry == REGISTRY
+    assert pup.registry_files.sort() == list(REGISTRY).sort()
+
+    # Text mode
+    pup = Pooch(path="", base_url="")
+    with open(path, "r") as fin:
+        pup.load_registry(fin)
+    assert pup.registry == REGISTRY
+    assert pup.registry_files.sort() == list(REGISTRY).sort()
+
+
 def test_pooch_load_registry_custom_url():
     "Load the registry from a file with a custom URL inserted"
     pup = Pooch(path="", base_url="")


### PR DESCRIPTION
This makes it possible to pass a file object to `load_registry()`, opened either in binary or text mode.

My main reason for this is to support passing `pkg_resources.resource_stream()` to it, which is the preferred way of using data files from the package (it will allow your package to be "zip-safe" though that doesn't matter as much those days).

This could be updated:
https://github.com/fatiando/pooch/blob/9a1382d68df2345f6120fd36456537a8a495e1db/doc/usage.rst#L461
to this:
```python
GOODBOY.load_registry(pkg_resources.resource_stream("plumbus", "registry.txt"))
```

**Reminders**

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst`.
- [x] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.