### PR TITLE
Make docstrings 79 characters (check with flake8)

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -24,52 +24,56 @@ def create(
     urls=None,
 ):
     """
-    Create a new :class:`~pooch.Pooch` with sensible defaults to fetch data files.
+    Create a :class:`~pooch.Pooch` with sensible defaults to fetch data files.
 
-    If a version string is given, the Pooch will be versioned, meaning that the local
-    storage folder and the base URL depend on the project version. This is necessary
-    if your users have multiple versions of your library installed (using virtual
-    environments) and you updated the data files between versions. Otherwise, every time
-    a user switches environments would trigger a re-download of the data. The version
-    string will be appended to the local storage path (for example,
-    ``~/.mypooch/cache/v0.1``) and inserted into the base URL (for example,
-    ``https://github.com/fatiando/pooch/raw/v0.1/data``). If the version string contains
-    ``+XX.XXXXX``, it will be interpreted as a development version.
+    If a version string is given, the Pooch will be versioned, meaning that the
+    local storage folder and the base URL depend on the project version. This
+    is necessary if your users have multiple versions of your library installed
+    (using virtual environments) and you updated the data files between
+    versions. Otherwise, every time a user switches environments would trigger
+    a re-download of the data. The version string will be appended to the local
+    storage path (for example, ``~/.mypooch/cache/v0.1``) and inserted into the
+    base URL (for example,
+    ``https://github.com/fatiando/pooch/raw/v0.1/data``). If the version string
+    contains ``+XX.XXXXX``, it will be interpreted as a development version.
 
     Parameters
     ----------
     path : str, PathLike, list or tuple
-        The path to the local data storage folder. If this is a list or tuple, we'll
-        join the parts with the appropriate separator. The *version* will be appended to
-        the end of this path. Use :func:`pooch.os_cache` for a sensible default.
+        The path to the local data storage folder. If this is a list or tuple,
+        we'll join the parts with the appropriate separator. The *version* will
+        be appended to the end of this path. Use :func:`pooch.os_cache` for a
+        sensible default.
     base_url : str
-        Base URL for the remote data source. All requests will be made relative to this
-        URL. The string should have a ``{version}`` formatting mark in it. We will call
-        ``.format(version=version)`` on this string. If the URL is a directory path, it
-        must end in a ``'/'`` because we will not include it.
+        Base URL for the remote data source. All requests will be made relative
+        to this URL. The string should have a ``{version}`` formatting mark in
+        it. We will call ``.format(version=version)`` on this string. If the
+        URL is a directory path, it must end in a ``'/'`` because we will not
+        include it.
     version : str or None
-        The version string for your project. Should be PEP440 compatible. If None is
-        given, will not attempt to format *base_url* and no subfolder will be appended
-        to *path*.
+        The version string for your project. Should be PEP440 compatible. If
+        None is given, will not attempt to format *base_url* and no subfolder
+        will be appended to *path*.
     version_dev : str
-        The name used for the development version of a project. If your data is hosted
-        on Github (and *base_url* is a Github raw link), then ``"master"`` is a good
-        choice (default). Ignored if *version* is None.
+        The name used for the development version of a project. If your data is
+        hosted on Github (and *base_url* is a Github raw link), then
+        ``"master"`` is a good choice (default). Ignored if *version* is None.
     env : str or None
-        An environment variable that can be used to overwrite *path*. This allows users
-        to control where they want the data to be stored. We'll append *version* to the
-        end of this value as well.
+        An environment variable that can be used to overwrite *path*. This
+        allows users to control where they want the data to be stored. We'll
+        append *version* to the end of this value as well.
     registry : dict or None
-        A record of the files that are managed by this Pooch. Keys should be the file
-        names and the values should be their SHA256 hashes. Only files in the registry
-        can be fetched from the local storage. Files in subdirectories of *path* **must
-        use Unix-style separators** (``'/'``) even on Windows.
+        A record of the files that are managed by this Pooch. Keys should be
+        the file names and the values should be their SHA256 hashes. Only files
+        in the registry can be fetched from the local storage. Files in
+        subdirectories of *path* **must use Unix-style separators** (``'/'``)
+        even on Windows.
     urls : dict or None
-        Custom URLs for downloading individual files in the registry. A dictionary with
-        the file names as keys and the custom URLs as values. Not all files in
-        *registry* need an entry in *urls*. If a file has an entry in *urls*, the
-        *base_url* will be ignored when downloading it in favor of ``urls[fname]``.
-
+        Custom URLs for downloading individual files in the registry. A
+        dictionary with the file names as keys and the custom URLs as values.
+        Not all files in *registry* need an entry in *urls*. If a file has an
+        entry in *urls*, the *base_url* will be ignored when downloading it in
+        favor of ``urls[fname]``.
 
     Returns
     -------
@@ -115,8 +119,9 @@ def create(
     >>> print(pup.base_url)
     http://some.link.com/
 
-    To place the storage folder at a subdirectory, pass in a list and we'll join the
-    path for you using the appropriate separator for your operating system:
+    To place the storage folder at a subdirectory, pass in a list and we'll
+    join the path for you using the appropriate separator for your operating
+    system:
 
     >>> pup = create(path=["myproject", "cache", "data"],
     ...              base_url="http://some.link.com/{version}/",
@@ -135,13 +140,13 @@ def create(
     ('myproject', 'not_from_env', 'v0.1')
     >>> # Set the environment variable and try again
     >>> import os
-    >>> os.environ["MYPROJECT_DATA_DIR"] = os.path.join("myproject", "from_env")
-    >>> pup = create(path=["myproject", "not_from_env"],
+    >>> os.environ["MYPROJECT_DATA_DIR"] = os.path.join("myproject", "env")
+    >>> pup = create(path=["myproject", "not_env"],
     ...              base_url="http://some.link.com/{version}/",
     ...              version="v0.1",
     ...              env="MYPROJECT_DATA_DIR")
     >>> print(pup.path.parts)
-    ('myproject', 'from_env', 'v0.1')
+    ('myproject', 'env', 'v0.1')
 
     """
     if isinstance(path, (list, tuple)):
@@ -180,26 +185,29 @@ class Pooch:
     """
     Manager for a local data storage that can fetch from a remote source.
 
-    Avoid creating ``Pooch`` instances directly. Use :func:`pooch.create` instead.
+    Avoid creating ``Pooch`` instances directly. Use :func:`pooch.create`
+    instead.
 
     Parameters
     ----------
     path : str
-        The path to the local data storage folder. The path must exist in the file
-        system.
+        The path to the local data storage folder. The path must exist in the
+        file system.
     base_url : str
-        Base URL for the remote data source. All requests will be made relative to this
-        URL.
+        Base URL for the remote data source. All requests will be made relative
+        to this URL.
     registry : dict or None
-        A record of the files that are managed by this good boy. Keys should be the file
-        names and the values should be their SHA256 hashes. Only files in the registry
-        can be fetched from the local storage. Files in subdirectories of *path* **must
-        use Unix-style separators** (``'/'``) even on Windows.
+        A record of the files that are managed by this good boy. Keys should be
+        the file names and the values should be their SHA256 hashes. Only files
+        in the registry can be fetched from the local storage. Files in
+        subdirectories of *path* **must use Unix-style separators** (``'/'``)
+        even on Windows.
     urls : dict or None
-        Custom URLs for downloading individual files in the registry. A dictionary with
-        the file names as keys and the custom URLs as values. Not all files in
-        *registry* need an entry in *urls*. If a file has an entry in *urls*, the
-        *base_url* will be ignored when downloading it in favor of ``urls[fname]``.
+        Custom URLs for downloading individual files in the registry. A
+        dictionary with the file names as keys and the custom URLs as values.
+        Not all files in *registry* need an entry in *urls*. If a file has an
+        entry in *urls*, the *base_url* will be ignored when downloading it in
+        favor of ``urls[fname]``.
 
     """
 
@@ -227,44 +235,47 @@ class Pooch:
         """
         Get the absolute path to a file in the local storage.
 
-        If it's not in the local storage, it will be downloaded. If the hash of the file
-        in local storage doesn't match the one in the registry, will download a new copy
-        of the file. This is considered a sign that the file was updated in the remote
-        storage. If the hash of the downloaded file still doesn't match the one in the
-        registry, will raise an exception to warn of possible file corruption.
+        If it's not in the local storage, it will be downloaded. If the hash of
+        the file in local storage doesn't match the one in the registry, will
+        download a new copy of the file. This is considered a sign that the
+        file was updated in the remote storage. If the hash of the downloaded
+        file still doesn't match the one in the registry, will raise an
+        exception to warn of possible file corruption.
 
         Post-processing actions sometimes need to be taken on downloaded files
-        (unzipping, conversion to a more efficient format, etc). If these actions are
-        time or memory consuming, it would be best to do this only once when the file is
-        actually downloaded. Use the *processor* argument to specify a function that is
-        executed after the downloaded (if required) to perform these actions. See below.
+        (unzipping, conversion to a more efficient format, etc). If these
+        actions are time or memory consuming, it would be best to do this only
+        once when the file is actually downloaded. Use the *processor* argument
+        to specify a function that is executed after the downloaded (if
+        required) to perform these actions. See below.
 
-        Custom file downloaders can be provided through the *downloader* argument. By
-        default, files are downloaded over HTTP. If the server for a given file requires
-        authentication (username and password) or if the file is served over FTP, use
-        custom downloaders that support these features. Downloaders can also be used to
-        print custom messages (like a progress bar), etc. See below for details.
+        Custom file downloaders can be provided through the *downloader*
+        argument. By default, files are downloaded over HTTP. If the server for
+        a given file requires authentication (username and password) or if the
+        file is served over FTP, use custom downloaders that support these
+        features. Downloaders can also be used to print custom messages (like a
+        progress bar), etc. See below for details.
 
         Parameters
         ----------
         fname : str
-            The file name (relative to the *base_url* of the remote data storage) to
-            fetch from the local storage.
+            The file name (relative to the *base_url* of the remote data
+            storage) to fetch from the local storage.
         processor : None or callable
-            If not None, then a function (or callable object) that will be called
-            before returning the full path and after the file has been downloaded (if
-            required). See below for details.
+            If not None, then a function (or callable object) that will be
+            called before returning the full path and after the file has been
+            downloaded (if required). See below for details.
         downloader : None or callable
-            If not None, then a function (or callable object) that will be called to
-            download a given URL to a provided local file name. By default, downloads
-            are done through HTTP without authentication using
-            :class:`pooch.HTTPDownloader`. See below for details.
+            If not None, then a function (or callable object) that will be
+            called to download a given URL to a provided local file name. By
+            default, downloads are done through HTTP without authentication
+            using :class:`pooch.HTTPDownloader`. See below for details.
 
         Returns
         -------
         full_path : str
-            The absolute path (including the file name) of the file in the local
-            storage.
+            The absolute path (including the file name) of the file in the
+            local storage.
 
         Notes
         -----
@@ -282,16 +293,17 @@ class Pooch:
                 fname : str
                     The full path of the file in the local data storage
                 action : str
-                    Either:
-                    "download" (file doesn't exist and will be downloaded),
-                    "update" (file is outdated and will be downloaded), or
-                    "fetch" (file exists and is updated so no download is necessary).
+                    Either: "download" (file doesn't exist and will be
+                    downloaded), "update" (file is outdated and will be
+                    downloaded), or "fetch" (file exists and is updated so no
+                    download is necessary).
                 pooch : pooch.Pooch
-                    The instance of the Pooch class that is calling this function.
+                    The instance of the Pooch class that is calling this
+                    function.
 
-                The return value can be anything but is usually a full path to a file
-                (or list of files). This is what will be returned by *fetch* in place of
-                the original file path.
+                The return value can be anything but is usually a full path to
+                a file (or list of files). This is what will be returned by
+                *fetch* in place of the original file path.
                 '''
                 ...
                 return full_path
@@ -311,21 +323,24 @@ class Pooch:
                 output_file : str or file-like object
                     Path (and file name) to which the file will be downloaded.
                 pooch : pooch.Pooch
-                    The instance of the Pooch class that is calling this function.
+                    The instance of the Pooch class that is calling this
+                    function.
 
                 No return value is required.
                 '''
                 ...
 
-        **Authentication** through HTTP can be handled by :class:`pooch.HTTPDownloader`:
+        **Authentication** through HTTP can be handled by
+        :class:`pooch.HTTPDownloader`:
 
         .. code:: python
 
             authdownload = HTTPDownloader(auth=(username, password))
             mypooch.fetch("some-data-file.txt", downloader=authdownload)
 
-        **Progress bar** for the download can be printed by :class:`pooch.HTTPDownloader`
-        by passing the argument ``progressbar=True``:
+        **Progress bar** for the download can be printed by
+        :class:`pooch.HTTPDownloader` by passing the argument
+        ``progressbar=True``:
 
         .. code:: python
 
@@ -360,10 +375,11 @@ class Pooch:
             )
             if downloader is None:
                 downloader = HTTPDownloader()
-            # Stream the file to a temporary so that we can safely check its hash before
-            # overwriting the original
+            # Stream the file to a temporary so that we can safely check its
+            # hash before overwriting the original
             tmp = tempfile.NamedTemporaryFile(delete=False, dir=str(self.abspath))
-            # Close the temp file so that the downloader can decide how to opened it
+            # Close the temp file so that the downloader can decide how to
+            # opened it
             tmp.close()
             try:
                 downloader(self.get_url(fname), tmp.name, self)
@@ -384,7 +400,8 @@ class Pooch:
 
     def _assert_file_in_registry(self, fname):
         """
-        Check if a file is in the registry and raise :class:`ValueError` if it's not.
+        Check if a file is in the registry and raise :class:`ValueError` if
+        it's not.
         """
         if fname not in self.registry:
             raise ValueError("File '{}' is not in the registry.".format(fname))
@@ -396,8 +413,8 @@ class Pooch:
         Parameters
         ----------
         fname : str
-            The file name (relative to the *base_url* of the remote data storage) to
-            fetch from the local storage.
+            The file name (relative to the *base_url* of the remote data
+            storage) to fetch from the local storage.
 
         """
         self._assert_file_in_registry(fname)
@@ -435,9 +452,10 @@ class Pooch:
 
         Use this if you are managing many files.
 
-        Each line of the file should have file name and its SHA256 hash separate by a
-        space. Only one file per line is allowed. Custom download URLs for individual
-        files can be specified as a third element on the line.
+        Each line of the file should have file name and its SHA256 hash
+        separate by a space. Only one file per line is allowed. Custom download
+        URLs for individual files can be specified as a third element on the
+        line.
 
         Parameters
         ----------
@@ -475,14 +493,14 @@ class Pooch:
         """
         Check availability of a remote file without downloading it.
 
-        Use this method when working with large files to check if they are available for
-        download.
+        Use this method when working with large files to check if they are
+        available for download.
 
         Parameters
         ----------
         fname : str
-            The file name (relative to the *base_url* of the remote data storage) to
-            fetch from the local storage.
+            The file name (relative to the *base_url* of the remote data
+            storage) to fetch from the local storage.
 
         Returns
         -------

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -15,23 +15,24 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
     """
     Download manager for fetching files over HTTP/HTTPS.
 
-    When called, downloads the given file URL into the specified local file. Uses the
-    :mod:`requests` library to manage downloads.
+    When called, downloads the given file URL into the specified local file.
+    Uses the :mod:`requests` library to manage downloads.
 
-    Use with :meth:`pooch.Pooch.fetch` to customize the download of files (for example,
-    to use authentication or print a progress bar).
+    Use with :meth:`pooch.Pooch.fetch` to customize the download of files (for
+    example, to use authentication or print a progress bar).
 
     Parameters
     ----------
     progressbar : bool
-        If True, will print a progress bar of the download to standard error (stderr).
-        Requires `tqdm <https://github.com/tqdm/tqdm>`__ to be installed.
+        If True, will print a progress bar of the download to standard error
+        (stderr). Requires `tqdm <https://github.com/tqdm/tqdm>`__ to be
+        installed.
     chunk_size : int
-        Files are streamed *chunk_size* bytes at a time instead of loading everything
-        into memory at one. Usually doesn't need to be changed.
+        Files are streamed *chunk_size* bytes at a time instead of loading
+        everything into memory at one. Usually doesn't need to be changed.
     **kwargs
-        All keyword arguments given when creating an instance of this class will be
-        passed to :func:`requests.get`.
+        All keyword arguments given when creating an instance of this class
+        will be passed to :func:`requests.get`.
 
     Examples
     --------
@@ -40,8 +41,8 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
 
     >>> import os
     >>> from pooch import version, check_version
-    >>> url = "https://github.com/fatiando/pooch/raw/{}/data/tiny-data.txt".format(
-    ...     check_version(version.full_version))
+    >>> url = "https://github.com/fatiando/pooch/raw/{}/data/tiny-data.txt"
+    >>> url = url.format(check_version(version.full_version))
     >>> downloader = HTTPDownloader()
     >>> # Not using with Pooch.fetch so no need to pass an instance of Pooch
     >>> downloader(url=url, output_file="tiny-data.txt", pooch=None)
@@ -54,10 +55,11 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
     >>> os.remove("tiny-data.txt")
 
     Authentication can be handled by passing a user name and password to
-    :func:`requests.get`. All arguments provided when creating an instance of the class
-    are forwarded to :func:`requests.get`. We'll use ``auth=(username, password)`` to
-    use basic HTTPS authentication. The https://httpbin.org website allows us to make a
-    fake a login request using whatever username and password we provide to it:
+    :func:`requests.get`. All arguments provided when creating an instance of
+    the class are forwarded to :func:`requests.get`. We'll use
+    ``auth=(username, password)`` to use basic HTTPS authentication. The
+    https://httpbin.org website allows us to make a fake a login request using
+    whatever username and password we provide to it:
 
     >>> user = "doggo"
     >>> password = "goodboy"
@@ -70,7 +72,7 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
     ... except Exception:
     ...     print("There was an error!")
     There was an error!
-    >>> # Pass in the credentials to HTTPDownloader and it will forward to requests.get
+    >>> # Pass in the credentials to HTTPDownloader
     >>> downloader = HTTPDownloader(auth=(user, password))
     >>> downloader(url=url, output_file="tiny-data.txt", pooch=None)
     >>> with open("tiny-data.txt") as f:
@@ -118,8 +120,9 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
             content = response.iter_content(chunk_size=self.chunk_size)
             if self.progressbar:
                 total = int(response.headers.get("content-length", 0))
-                # Need to use ascii characters on Windows because there isn't always
-                # full unicode support (see https://github.com/tqdm/tqdm/issues/454)
+                # Need to use ascii characters on Windows because there isn't
+                # always full unicode support
+                # (see https://github.com/tqdm/tqdm/issues/454)
                 use_ascii = bool(sys.platform == "win32")
                 progress = tqdm(
                     total=total,
@@ -134,14 +137,14 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
                     output_file.write(chunk)
                     output_file.flush()
                     if self.progressbar:
-                        # Use the chunk size here because chunk may be much larger if
-                        # the data are decompressed by requests after reading (happens
-                        # with text files).
+                        # Use the chunk size here because chunk may be much
+                        # larger if the data are decompressed by requests after
+                        # reading (happens with text files).
                         progress.update(self.chunk_size)
-            # Make sure the progress bar gets filled even if the actual number is
-            # chunks is smaller than expected. This happens when streaming text files
-            # that are compressed by the server when sending (gzip). Binary files don't
-            # experience this.
+            # Make sure the progress bar gets filled even if the actual number
+            # is chunks is smaller than expected. This happens when streaming
+            # text files that are compressed by the server when sending (gzip).
+            # Binary files don't experience this.
             if self.progressbar:
                 progress.reset()
                 progress.update(total)

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -30,7 +30,8 @@ class ExtractorProcessor:  # pylint: disable=too-few-public-methods
 
     """
 
-    suffix = None  # String appended to unpacked archive. To be implemented in subclass
+    # String appended to unpacked archive. To be implemented in subclass
+    suffix = None
 
     def __init__(self, members=None):
         self.members = members
@@ -44,11 +45,11 @@ class ExtractorProcessor:  # pylint: disable=too-few-public-methods
         fname : str
             Full path of the zipped file in local storage.
         action : str
-            Indicates what action was taken by :meth:`pooch.Pooch.fetch`. One of:
+            Indicates what action was taken by :meth:`pooch.Pooch.fetch`:
 
-            * ``"download"``: The file didn't exist locally and was downloaded
-            * ``"update"``: The local file was outdated and was re-download
-            * ``"fetch"``: The file exists and is updated so it wasn't downloaded
+            * ``"download"``: File didn't exist locally and was downloaded
+            * ``"update"``: Local file was outdated and was re-download
+            * ``"fetch"``: File exists and is updated so it wasn't downloaded
 
         pooch : :class:`pooch.Pooch`
             The instance of :class:`pooch.Pooch` that is calling this.
@@ -69,8 +70,8 @@ class ExtractorProcessor:  # pylint: disable=too-few-public-methods
             if not os.path.exists(extract_dir):
                 os.makedirs(extract_dir)
             self._extract_file(fname, extract_dir)
-        # Get a list of all file names (including subdirectories) in our folder of
-        # unzipped files.
+        # Get a list of all file names (including subdirectories) in our folder
+        # of unzipped files.
         fnames = [
             os.path.join(path, fname)
             for path, _, files in os.walk(extract_dir)
@@ -90,18 +91,18 @@ class Unzip(ExtractorProcessor):  # pylint: disable=too-few-public-methods
     """
     Processor that unpacks a zip archive and returns a list of all files.
 
-    Use with :meth:`pooch.Pooch.fetch` to unzip a downloaded data file into a folder in
-    the local data store. :meth:`~pooch.Pooch.fetch` will return a list with the names
-    of the unzipped files instead of the zip archive.
+    Use with :meth:`pooch.Pooch.fetch` to unzip a downloaded data file into a
+    folder in the local data store. :meth:`~pooch.Pooch.fetch` will return a
+    list with the names of the unzipped files instead of the zip archive.
 
     The output folder is ``{fname}.unzip``.
 
     Parameters
     ----------
     members : list or None
-        If None, will unpack all files in the zip archive. Otherwise, *members* must be
-        a list of file names to unpack from the archive. Only these files will be
-        unpacked.
+        If None, will unpack all files in the zip archive. Otherwise, *members*
+        must be a list of file names to unpack from the archive. Only these
+        files will be unpacked.
 
     """
 
@@ -135,9 +136,9 @@ class Untar(ExtractorProcessor):  # pylint: disable=too-few-public-methods
     """
     Processor that unpacks a tar archive and returns a list of all files.
 
-    Use with :meth:`pooch.Pooch.fetch` to untar a downloaded data file into a folder in
-    the local data store. :meth:`~pooch.Pooch.fetch` will return a list with the names
-    of the extracted files instead of the archive.
+    Use with :meth:`pooch.Pooch.fetch` to untar a downloaded data file into a
+    folder in the local data store. :meth:`~pooch.Pooch.fetch` will return a
+    list with the names of the extracted files instead of the archive.
 
     The output folder is ``{fname}.untar``.
 
@@ -145,9 +146,9 @@ class Untar(ExtractorProcessor):  # pylint: disable=too-few-public-methods
     Parameters
     ----------
     members : list or None
-        If None, will unpack all files in the archive. Otherwise, *members* must be
-        a list of file names to unpack from the archive. Only these files will be
-        unpacked.
+        If None, will unpack all files in the archive. Otherwise, *members*
+        must be a list of file names to unpack from the archive. Only these
+        files will be unpacked.
     """
 
     suffix = ".untar"
@@ -184,23 +185,24 @@ class Decompress:  # pylint: disable=too-few-public-methods
     """
     Processor that decompress a file and returns the decompressed version.
 
-    Use with :meth:`pooch.Pooch.fetch` to decompress a downloaded data file so that it
-    can be easily opened. Useful for data files that take a long time to decompress
-    (exchanging disk space for speed).
+    Use with :meth:`pooch.Pooch.fetch` to decompress a downloaded data file so
+    that it can be easily opened. Useful for data files that take a long time
+    to decompress (exchanging disk space for speed).
 
     The output file is ``{fname}.decomp``.
 
-    Supported decompression methods are LZMA (``.xz``), bzip2 (``.bz2``), and gzip
-    (``.gz``).
+    Supported decompression methods are LZMA (``.xz``), bzip2 (``.bz2``), and
+    gzip (``.gz``).
 
-    File names with the standard extensions (see above) can use ``method="auto"`` to
-    automatically determine the compression method. This can be overwritten by setting
-    the *method* argument.
+    File names with the standard extensions (see above) can use
+    ``method="auto"`` to automatically determine the compression method. This
+    can be overwritten by setting the *method* argument.
 
     Parameters
     ----------
     method : str
-        Name of the compression method. Can be "auto", "lzma", "xz", "bzip2", or "gzip".
+        Name of the compression method. Can be "auto", "lzma", "xz", "bzip2",
+        or "gzip".
 
     """
 
@@ -220,11 +222,11 @@ class Decompress:  # pylint: disable=too-few-public-methods
         fname : str
             Full path of the compressed file in local storage.
         action : str
-            Indicates what action was taken by :meth:`pooch.Pooch.fetch`. One of:
+            Indicates what action was taken by :meth:`pooch.Pooch.fetch`:
 
-            - ``"download"``: The file didn't exist locally and was downloaded
-            - ``"update"``: The local file was outdated and was re-download
-            - ``"fetch"``: The file exists and is updated so it wasn't downloaded
+            - ``"download"``: File didn't exist locally and was downloaded
+            - ``"update"``: Local file was outdated and was re-download
+            - ``"fetch"``: File exists and is updated so it wasn't downloaded
 
         pooch : :class:`pooch.Pooch`
             The instance of :class:`pooch.Pooch` that is calling this.
@@ -249,7 +251,7 @@ class Decompress:  # pylint: disable=too-few-public-methods
 
     def _compression_module(self, fname):
         """
-        Get the Python compression module compatible with fname and the chosen method.
+        Get the Python module compatible with fname and the chosen method.
 
         If the *method* attribute is "auto", will select a method based on the
         extension. If no recognized extension is in the file name, will raise a

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -94,8 +94,8 @@ def test_pooch_update():
     "Setup a pooch that already has the local data but the file is outdated"
     with TemporaryDirectory() as local_store:
         path = Path(local_store)
-        # Create a dummy version of tiny-data.txt that is different from the one in the
-        # remote storage
+        # Create a dummy version of tiny-data.txt that is different from the
+        # one in the remote storage
         true_path = str(path / "tiny-data.txt")
         with open(true_path, "w") as fin:
             fin.write("different data")
@@ -119,7 +119,7 @@ def test_pooch_update():
 
 
 def test_pooch_corrupted():
-    "Raise an exception if the hash of downloaded file doesn't match the registry"
+    "Raise an exception if the file hash doesn't match the registry"
     # Test the case where the file wasn't in the directory
     with TemporaryDirectory() as local_store:
         path = os.path.abspath(local_store)
@@ -225,8 +225,8 @@ def test_create_makedirs_permissionerror(monkeypatch):
 
 def test_create_newfile_permissionerror(monkeypatch):
     "Should warn the user when can't write to the local data dir"
-    # This is a separate function because there should be a warning if the data dir
-    # already exists but we can't write to it.
+    # This is a separate function because there should be a warning if the data
+    # dir already exists but we can't write to it.
 
     def mocktempfile(**kwargs):  # pylint: disable=unused-argument
         "Raise an exception to mimic permission issues"
@@ -316,7 +316,7 @@ def test_downloader_progressbar(capsys):
         # Setup a pooch in a temp dir
         pup = Pooch(path=path, base_url=BASEURL, registry=REGISTRY)
         fname = pup.fetch("large-data.txt", downloader=download)
-        # Read stderr and make sure the progress bar is printed only when told to
+        # Read stderr and make sure the progress bar is printed only when told
         captured = capsys.readouterr()
         printed = captured.err.split("\r")[-1].strip()
         assert len(printed) == 79
@@ -324,7 +324,7 @@ def test_downloader_progressbar(capsys):
             progress = "100%|####################"
         else:
             progress = "100%|████████████████████"
-        # The bar size is not always the same so we can't reliably test the whole bar.
+        # Bar size is not always the same so can't reliably test the whole bar.
         assert printed[:25] == progress
         # Check that the downloaded file has the right content
         check_large_data(fname)

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -83,7 +83,7 @@ def test_extractprocessor_fails():
     "proc_cls,ext", [(Unzip, ".zip"), (Untar, ".tar.gz")], ids=["Unzip", "Untar"]
 )
 def test_processors(proc_cls, ext):
-    "Setup a post-download hook and make sure it's only executed when downloading"
+    "Setup a hook and make sure it's only executed when downloading"
     processor = proc_cls(members=["tiny-data.txt"])
     suffix = proc_cls.suffix
     extract_dir = "tiny-data" + ext + suffix

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -37,8 +37,8 @@ def pooch_test_url():
     Get the base URL for the test data used in Pooch itself.
 
     The URL is a github raw link to the ``pooch/tests/data`` directory from the
-    `Github repository <https://github.com/fatiando/pooch>`__. It matches the pooch
-    version specified in ``pooch.version.full_version``.
+    `Github repository <https://github.com/fatiando/pooch>`__. It matches the
+    pooch version specified in ``pooch.version.full_version``.
 
     Returns
     -------

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -29,8 +29,8 @@ def os_cache(project):
     Returns
     -------
     cache_path : :class:`pathlib.Path`
-        The default location for the data cache. User directories (``'~'``) are not
-        expanded.
+        The default location for the data cache. User directories (``'~'``) are
+        not expanded.
 
     """
     return Path(appdirs.user_cache_dir(project))
@@ -77,12 +77,12 @@ def file_hash(fname):
 
 def check_version(version, fallback="master"):
     """
-    Check that a version string is PEP440 compliant and there are no unreleased changes.
+    Check if a version is PEP440 compliant and there are no unreleased changes.
 
-    For example, ``version = "0.1"`` will be returned as is but
-    ``version = "0.1+10.8dl8dh9"`` will return the fallback. This is the convention used
-    by `versioneer <https://github.com/warner/python-versioneer>`__ to mark that this
-    version is 10 commits ahead of the last release.
+    For example, ``version = "0.1"`` will be returned as is but ``version =
+    "0.1+10.8dl8dh9"`` will return the fallback. This is the convention used by
+    `versioneer <https://github.com/warner/python-versioneer>`__ to mark that
+    this version is 10 commits ahead of the last release.
 
     Parameters
     ----------
@@ -94,8 +94,8 @@ def check_version(version, fallback="master"):
     Returns
     -------
     version : str
-        If *version* is PEP440 compliant and there are unreleased changes, then return
-        *version*. Otherwise, return *fallback*.
+        If *version* is PEP440 compliant and there are unreleased changes, then
+        return *version*. Otherwise, return *fallback*.
 
     Raises
     ------
@@ -131,12 +131,13 @@ def make_registry(directory, output, recursive=True):
     Parameters
     ----------
     directory : str
-        Directory of the test data to put in the registry. All file names in the
-        registry will be relative to this directory.
+        Directory of the test data to put in the registry. All file names in
+        the registry will be relative to this directory.
     output : str
         Name of the output registry file.
     recursive : bool
-        If True, will recursively look for files in subdirectories of *directory*.
+        If True, will recursively look for files in subdirectories of
+        *directory*.
 
     """
     directory = Path(directory)
@@ -157,6 +158,6 @@ def make_registry(directory, output, recursive=True):
 
     with open(output, "w") as outfile:
         for fname, fhash in zip(files, hashes):
-            # Only use Unix separators for the registry so that we don't go insane
-            # dealing with file paths.
+            # Only use Unix separators for the registry so that we don't go
+            # insane dealing with file paths.
             outfile.write("{} {}\n".format(fname.replace("\\", "/"), fhash))

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,4 @@ tag_prefix = ''
 [flake8]
 ignore = E203, E266, E501, W503, F401, E741
 max-line-length = 88
+max-doc-length = 79


### PR DESCRIPTION
Docstrings with 88 characters (the Black line length) don't show up
nicely in Jupyter and IPython (since the display is 80 chars). This
means that our docstrings were unreadable.
See fatiando/verde#177 fatiando/contributing#9 fatiando/contributing#10
for context.
Make flake8 check that docstrings (and comments, sadly) are 79
characters so we can make sure we don't do it again accidentally.
Have to check comments as well because the flake8 flag doesn't
discriminate between them.

Fixes #121 



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
