### PR TITLE
Use file name in exception for hash mismatch

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -455,9 +455,9 @@ class Pooch:
         tmphash = file_hash(downloaded)
         if tmphash != self.registry[fname]:
             raise ValueError(
-                "Hash of downloaded file '{}' doesn't match the entry in the registry:"
+                "Hash of downloaded file '{}' doesn't match the entry in the registry."
                 " Expected '{}' and got '{}'.".format(
-                    downloaded, self.registry[fname], tmphash
+                    fname, self.registry[fname], tmphash
                 )
             )
 


### PR DESCRIPTION
When the hash of the downloaded file doesn't match the one in the
registry, we raise an exception informing the hashes and the name of the
downloaded temporary file. But the temp file is deleted and its name has
nothing to do with the file in the registry. Instead, inform the actual
file name.

Fixes #96


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
