### PR TITLE
Add registry file and bad content to error message

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -493,8 +493,10 @@ class Pooch:
                 elements = line.strip().split()
                 if len(elements) > 3 or len(elements) < 2:
                     raise OSError(
-                        "Expected 2 or 3 elements in line {} but got {}.".format(
-                            linenum, len(elements)
+                        "Invalid entry in Pooch registry file '{}': "
+                        "expected 2 or 3 elements in line {} but got {}. "
+                        "Offending entry: '{}'".format(
+                            fname, linenum, len(elements), line
                         )
                     )
                 file_name = elements[0]


### PR DESCRIPTION
When loading a registry file, inform the name of the file and include
the offending content in the error message instead of just the line
number.

Fixes #88



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
