### PR TITLE
Expand the section on Intake and include fsspec

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -137,7 +137,7 @@ tar) and decompressing files (gzip, lzma, and bzip2).
 
 To the best of the authors' awareness, the only other Python software with some
 overlapping functionality are [Intake](https://github.com/intake/intake) and
-[fsspec](https://github.com/intake/filesystem_spec) (which is the backend for Intake).
+[fsspec](https://github.com/intake/filesystem_spec) (which is used by Intake).
 The fsspec library provides a unified interface for defining file systems and
 opening files, regardless of where the files are located (local system,
 HTTPS/FTP servers, Amazon S3, Google Cloud Storage, etc).
@@ -146,15 +146,13 @@ the one in Pooch, but has a wider range of download methods available.
 In the future, fsspec could be used as a backend to expand Pooch's download
 capabilities beyond HTTPS and FTP.
 Intake manages data catalogues (with download locations and extensive
-metadata), data download and caching (using fsspec), data loading,
-visualization, and browsing.
+metadata), data download and caching, data loading, visualization, and
+browsing.
 It has built-in capabilities for loading data into standard containers,
 including NumPy, pandas, and xarray.
-While Intake and fsspec are powerful and highly configurable,
-we argue that Pooch's advantage is in its simplicity.
-Pooch has a simpler setup and is more accessible to developers without advanced
-programming knowledge, meeting the immediate needs of busy scientific software
-authors and individual scientists.
+While Intake and fsspec are powerful and highly configurable tools,
+we argue that Pooch's strong points are its simplicity, straight-forward
+documentation, and focus on solving a single problem.
 
 The Pooch API is stable and has been field-tested by other projects:
 MetPy [@metpy], Verde [@verde], RockHound [@rockhound], predictatops

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -149,7 +149,7 @@ Intake manages data catalogues (with download locations and extensive
 metadata), data download and caching (using fsspec), data loading,
 visualization, and browsing.
 It has built-in capabilities for loading data into standard containers,
-including numpy, pandas, and xarray.
+including NumPy, pandas, and xarray.
 While Intake and fsspec are powerful and highly configurable,
 we argue that Pooch's advantage is in its simplicity.
 Pooch has a simpler setup and is more accessible to developers without advanced

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -136,13 +136,25 @@ authentication) as well as processing functions for unpacking archives (zip or
 tar) and decompressing files (gzip, lzma, and bzip2).
 
 To the best of the authors' awareness, the only other Python software with some
-overlapping functionality is [Intake](https://github.com/intake/intake).
-While Intake is powerful and can be used to manage large data archives,
-we argue that Pooch has a simpler setup and meets the
-specific needs of scientific software authors and individual scientists.
-For example, Pooch does not require users to change their data loading code to
-fit into a plug-in structure, instead only providing the file path for the
-user.
+overlapping functionality are [Intake](https://github.com/intake/intake) and
+[fsspec](https://github.com/intake/filesystem_spec) (which is the backend for Intake).
+The fsspec library provides a unified interface for defining file systems and
+opening files, regardless of where the files are located (local system,
+HTTPS/FTP servers, Amazon S3, Google Cloud Storage, etc).
+fsspec implements similar download and caching functionality to
+the one in Pooch, but has a wider range of download methods available.
+In the future, fsspec could be used as a backend to expand Pooch's download
+capabilities beyond HTTPS and FTP.
+Intake manages data catalogues (with download locations and extensive
+metadata), data download and caching (using fsspec), data loading,
+visualization, and browsing.
+It has built-in capabilities for loading data into standard containers,
+including numpy, pandas, and xarray.
+While Intake and fsspec are powerful and highly configurable,
+we argue that Pooch's advantage is in its simplicity.
+Pooch has a simpler setup and is more accessible to developers without advanced
+programming knowledge, meeting the immediate needs of busy scientific software
+authors and individual scientists.
 
 The Pooch API is stable and has been field-tested by other projects:
 MetPy [@metpy], Verde [@verde], RockHound [@rockhound], predictatops


### PR DESCRIPTION
As pointed out by reviewer @martindurant, we failed to mention fsspec in the "state of the field" section and could have done a better job at presenting Intake. Include a couple of sentences more on Intake and fsspec, how fsspec could be used in Pooch in the future, and what are the advantages and disadvantages of Pooch with respect to these tools.

openjournals/joss-reviews#1943
