### PR TITLE
Fix capitalization in JOSS paper references

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -11,7 +11,7 @@
 }
 
 @article{scikit-image,
-  title={scikit-image: image processing in Python},
+  title={scikit-image: image processing in {Python}},
   author={Van der Walt, Stefan and Sch{\"o}nberger, Johannes L and
           Nunez-Iglesias, Juan and Boulogne, Fran{\c{c}}ois and Warner,
           Joshua D and Yager, Neil and Gouillart, Emmanuelle and Yu, Tony},
@@ -36,7 +36,7 @@
 }
 
 @article{verde,
-  title={Verde: Processing and gridding spatial data using Green's functions},
+  title={Verde: Processing and gridding spatial data using {Green's} functions},
   doi={10.21105/joss.00957},
   url={https://doi.org/10.21105/joss.00957},
   year={2018},
@@ -54,7 +54,7 @@
   url={https://zenodo.org/record/3086002},
   author={Uieda,  Leonardo and Soler,  Santiago R.},
   language={en},
-  title={Rockhound: Download geophysical models/datasets and load them in Python},
+  title={Rockhound: Download geophysical models/datasets and load them in {Python}},
   publisher={Zenodo},
   year={2019}
 }
@@ -63,7 +63,7 @@
   doi = {10.5281/ZENODO.3542092},
   url = {https://zenodo.org/record/3542092},
   author = {Shapero,  Daniel and Lilien,  David and Ham,  David A. and Hoffman,  Andrew},
-  title = {icepack/icepack: icepack: glacier flow modeling with the finite element method in Python},
+  title = {icepack/icepack: icepack: glacier flow modeling with the finite element method in {Python}},
   publisher = {Zenodo},
   year = {2019}
 }
@@ -79,7 +79,7 @@
 
 @manual{cartopy,
   author = {{Met Office}},
-  title = {Cartopy: a cartographic Python library with a Matplotlib interface},
+  title = {Cartopy: a cartographic {Python} library with a {Matplotlib} interface},
   year = {2010 - 2015},
   address = {Exeter, Devon},
   url = {https://scitools.org.uk/cartopy}
@@ -95,6 +95,6 @@
   number = {37},
   pages = {1450},
   author = {C. Bane Sullivan and Alexander Kaszynski},
-  title = {{PyVista}: 3D plotting and mesh analysis through a streamlined interface for the Visualization Toolkit ({VTK})},
+  title = {{PyVista}: {3D} plotting and mesh analysis through a streamlined interface for the {Visualization} {Toolkit} ({VTK})},
   journal = {Journal of Open Source Software}
 }

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -11,7 +11,7 @@
 }
 
 @article{scikit-image,
-  title={scikit-image: image processing in {Python}},
+  title={{scikit-image}: {image} processing in {Python}},
   author={Van der Walt, Stefan and Sch{\"o}nberger, Johannes L and
           Nunez-Iglesias, Juan and Boulogne, Fran{\c{c}}ois and Warner,
           Joshua D and Yager, Neil and Gouillart, Emmanuelle and Yu, Tony},


### PR DESCRIPTION
Some of the Bibtex was poorly formated to preserve capitalization
(Python vs python).

openjournals/joss-reviews#1943


**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
