### PR TITLE
Add the retrive function to fetch single files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,25 @@ Here are Pooch's main features:
 Example
 -------
 
+For a **scientist downloading a data file** for analysis:
+
+.. code:: python
+
+    from pooch import retrieve
+
+
+    # Download the file and save it locally. Running this again will not cause
+    # a download. Pooch will check the hash (checksum) of the downloaded file
+    # against the given value to make sure it's the right file (not corrupted
+    # or outdated).
+    fname = retrieve(
+        url="https://some-data-server.org/a-data-file.nc",
+        known_hash="md5:70e2afd3fd7e336ae478b1e740a5f08e",
+    )
+
+
+For **package developers** including sample data in their projects:
+
 .. code:: python
 
     """

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -15,6 +15,7 @@ Core
 
     create
     Pooch
+    retrieve
 
 Utilities
 ---------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,5 +17,6 @@
     install.rst
     citing.rst
     usage.rst
+    retrieve.rst
     api/index.rst
     changes.rst

--- a/doc/retrieve.rst
+++ b/doc/retrieve.rst
@@ -1,0 +1,51 @@
+.. _retrieve:
+
+Downloading a single file
+=========================
+
+Sometimes, you just want to download a single file (caching it locally and
+checking the hash to make sure you have the right one). In these cases,
+:class:`pooch.Pooch` is overkill and requires too much setup.
+
+For that, :func:`pooch.retrieve` is what you want:
+
+.. code-block:: python
+
+    from pooch import retrieve
+
+
+    # Download the file and save it locally. Will check the MD5 checksum of
+    # the downloaded file against the given value to make sure it's the right
+    # file. You can use other hashes by specifying different algorithm
+    # names (sha256, sha1, etc).
+    fname = retrieve(
+        # URL to one of Pooch's test files
+        url="https://github.com/fatiando/pooch/raw/v1.0.0/data/tiny-data.txt",
+        known_hash="md5:70e2afd3fd7e336ae478b1e740a5f08e",
+    )
+
+The file is stored locally, by default in a ``pooch`` folder in the default
+cache location of your operating system (see :func:`pooch.os_cache`).
+Running this code a second time will not trigger a download, same as with
+:meth:`pooch.Pooch.fetch`.
+
+If you don't know the hash of the file, you can set ``known_hash=None`` to
+bypass the check. If this is the case, :func:`~pooch.retrieve` will show a log
+message with the SHA256 hash of the downloaded file. **It's highly recommended
+that you copy and paste this hash into your code** and use it as the
+``known_hash``. That way, the next time your code is run (by you or someone
+else) you can guarantee that the exact same file is downloaded. This is a way
+to help make sure the results of your code are reproducible.
+
+Function :func:`~pooch.retrieve` has support for all of Pooch's
+:ref:`custom downloaders <downloaders>` and
+:ref:`post-processing hooks <processors>`. So you can use HTTP and FTP (with or
+without authentication), decompress files, unpack archives, and print progress
+bars with a bit of configuration.
+
+.. note::
+
+    This function is meant for downloading single files. If you need to
+    manage the download and caching of several files, with versioning, use
+    :func:`pooch.create` and :class:`pooch.Pooch` instead. See :ref:`usage`.
+

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -144,26 +144,26 @@ Bypassing the hash check
 Sometimes we might not know the hash of the file or it could change on the server
 periodically. In these cases, we need a way of bypassing the hash check.
 One way of doing that is with Python's ``unittest.mock`` module. It defines the object
-``unittest.mock.ANY`` which passes all equality tests made against it. To bypass the 
-check, we can set the hash value to ``unittest.mock.ANY`` when specifying the 
+``unittest.mock.ANY`` which passes all equality tests made against it. To bypass the
+check, we can set the hash value to ``unittest.mock.ANY`` when specifying the
 ``registry`` argument for :func:`pooch.create`.
 
-In this example, we want to use Pooch to download a list of weather stations around 
-Australia. The file with the stations is in an FTP server and we want to store it locally 
-in separate folders for each day that the code is run. The problem is that the 
-``stations.zip`` file is updated on the server instead of creating a new one, so the 
+In this example, we want to use Pooch to download a list of weather stations around
+Australia. The file with the stations is in an FTP server and we want to store it locally
+in separate folders for each day that the code is run. The problem is that the
+``stations.zip`` file is updated on the server instead of creating a new one, so the
 hash check would fail. This is how you can solve this problem:
 
 
 .. code:: python
 
     import datetime
-    import unittest.mock  
+    import unittest.mock
     import pooch
 
     # Get the current data to store the files in separate folders
     CURRENT_DATE = datetime.datetime.now().date()
-    
+
     GOODBOY = pooch.create(
         path=pooch.os_cache("bom_daily_stations") / CURRENT_DATE,
         base_url="ftp://ftp.bom.gov.au/anon2/home/ncc/metadata/sitelists/",
@@ -173,14 +173,14 @@ hash check would fail. This is how you can solve this problem:
         },
     )
 
-Because hash check is always ``True``, Pooch will only download the file once. When running 
-again at a different date, the file will be downloaded again because the local cache folder 
-changed and the file is no longer present in it. If you omit ``CURRENT_DATE`` from the cache 
+Because hash check is always ``True``, Pooch will only download the file once. When running
+again at a different date, the file will be downloaded again because the local cache folder
+changed and the file is no longer present in it. If you omit ``CURRENT_DATE`` from the cache
 path, then Pooch will only fetch the files once, unless they are deleted from the cache.
 
-.. note:: 
+.. note::
 
-    If run over a period of time, your cache directory will increase in size, as the 
+    If run over a period of time, your cache directory will increase in size, as the
     files are stored in daily subdirectories.
 
 
@@ -239,6 +239,8 @@ saved to the same subdirectories in the local storage folder. Note, however, tha
 names of these files in the registry **must use Unix-style separators** (``'/'``) even
 on Windows. We will handle the appropriate conversions.
 
+
+.. _processors:
 
 Post-processing hooks
 ---------------------
@@ -373,6 +375,8 @@ keeping a decompressed copy of the file:
         data = numpy.load(fname)
         return data
 
+
+.. _downloaders:
 
 Downloaders and authentication
 ------------------------------

--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring,import-outside-toplevel
 # Import functions/classes to make the API
 from . import version
-from .core import Pooch, create
+from .core import Pooch, create, retrieve
 from .utils import os_cache, file_hash, make_registry, check_version, get_logger
 from .downloaders import HTTPDownloader, FTPDownloader
 from .processors import Unzip, Untar, Decompress

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -41,7 +41,9 @@ def retrieve(url, hash, path=None, fname=None, processor=None, downloader=None):
     os.makedirs(str(path), exist_ok=True)
 
 
-def _download_if_needed(url, path, fname, hash, pooch=None, processor=None, downloader=None):
+def _download_if_needed(
+    url, path, fname, hash, pooch=None, processor=None, downloader=None
+):
 
     full_path = path / fname
 

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -19,7 +19,7 @@ from .utils import (
     hash_algorithm,
     hash_matches,
     os_cache,
-    make_unique_file_name,
+    unique_file_name,
 )
 from .downloaders import HTTPDownloader, FTPDownloader
 

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -9,7 +9,14 @@ import tempfile
 import ftplib
 
 import requests
-from .utils import file_hash, check_version, parse_url, get_logger, make_local_storage
+from .utils import (
+    file_hash,
+    check_version,
+    parse_url,
+    get_logger,
+    make_local_storage,
+    hash_algorithm,
+)
 from .downloaders import HTTPDownloader, FTPDownloader
 
 KNOWN_DOWNLOADERS = {
@@ -364,7 +371,7 @@ class Pooch:
         if not in_storage:
             action = "download"
         else:
-            hash_alg = self.hash_algorithm(fname)
+            hash_alg = hash_algorithm(self.registry[fname])
             current_hash = "{}:{}".format(
                 hash_alg, file_hash(str(full_path), alg=hash_alg)
             )
@@ -455,7 +462,7 @@ class Pooch:
             If the hashes don't match.
 
         """
-        registry_hash_alg = self.hash_algorithm(fname)
+        registry_hash_alg = hash_algorithm(self.registry[fname])
         tmphash = "{}:{}".format(
             registry_hash_alg, file_hash(downloaded, alg=registry_hash_alg)
         )
@@ -551,21 +558,3 @@ class Pooch:
             response = requests.head(source, allow_redirects=True)
             available = bool(response.status_code == 200)
         return available
-
-    def hash_algorithm(self, fname):
-        """
-        Return the hash algorithm used to compute the file's checksum.
-
-        Parameters
-        ----------
-        fname : str
-            The file name (relative to the *base_url* of the remote data
-            storage) to fetch from the local storage.
-
-        Returns
-        -------
-        alg : str
-            The name of the hashing algorithm.
-        """
-        self._assert_file_in_registry(fname)
-        return self.registry[fname].split(":")[0]

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -332,7 +332,10 @@ def download_if_needed(
                 raise ValueError(
                     "Hash ({}) of downloaded file '{}' does not match the known hash."
                     " Expected '{}' and got '{}'.".format(
-                        hash_algorithm(known_hash), str(full_path), known_hash, new_hash,
+                        hash_algorithm(known_hash),
+                        str(full_path),
+                        known_hash,
+                        new_hash,
                     )
                 )
 

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import shutil
 import tempfile
 import ftplib
+import hashlib
 
 import requests
 from .utils import (
@@ -17,6 +18,8 @@ from .utils import (
     make_local_storage,
     hash_algorithm,
     hash_matches,
+    os_cache,
+    make_unique_file_name,
 )
 from .downloaders import HTTPDownloader, FTPDownloader
 
@@ -25,6 +28,75 @@ KNOWN_DOWNLOADERS = {
     "https": HTTPDownloader,
     "http": HTTPDownloader,
 }
+
+
+def retrieve(url, hash, path=None, fname=None, processor=None, downloader=None):
+    """
+    """
+    if path is None:
+        path = os_cache("pooch")
+    # Normalize the path and make sure it's an absolute path
+    path = Path(os.path.abspath(os.path.expanduser(str(path))))
+    # Create the local data directory if it doesn't already exist
+    os.makedirs(str(path), exist_ok=True)
+
+    in_storage = full_path.exists()
+
+    if not in_storage:
+        action = "download"
+    elif not hash_matches(str(full_path), self.registry[fname]):
+        action = "update"
+    else:
+        action = "fetch"
+
+    if action in ("download", "update"):
+        action_word = dict(download="Downloading", update="Updating")
+        get_logger().info(
+            "%s data file '%s' from remote data store '%s' to '%s'.",
+            action_word[action],
+            fname,
+            self.get_url(fname),
+            str(self.path),
+        )
+
+        parsed_url = parse_url(url)
+        if parsed_url["protocol"] not in KNOWN_DOWNLOADERS:
+            raise ValueError(
+                "Unrecognized URL protocol '{}' in '{}'. Must be one of {}.".format(
+                    parsed_url["protocol"], url, KNOWN_DOWNLOADERS.keys()
+                )
+            )
+
+        if downloader is None:
+            downloader = KNOWN_DOWNLOADERS[parsed_url["protocol"]]()
+        # Stream the file to a temporary so that we can safely check its
+        # hash before overwriting the original
+        tmp = tempfile.NamedTemporaryFile(delete=False, dir=str(self.abspath))
+        # Close the temp file so that the downloader can decide how to
+        # opened it
+        tmp.close()
+        try:
+            downloader(url, tmp.name, self)
+            if not hash_matches(tmp.name, self.registry[fname]):
+                raise ValueError(
+                    "Hash of downloaded file '{}' doesn't match the entry in the"
+                    " registry. Expected '{}' and got '{}'.".format(
+                        fname,
+                        self.registry[fname],
+                        file_hash(tmp.name, alg=hash_algorithm(self.registry[fname])),
+                    )
+                )
+            # Ensure the parent directory exists in case the file is in a
+            # subdirectory. Otherwise, move will cause an error.
+            if not os.path.exists(str(full_path.parent)):
+                os.makedirs(str(full_path.parent))
+            shutil.move(tmp.name, str(full_path))
+        finally:
+            if os.path.exists(tmp.name):
+                os.remove(tmp.name)
+
+    if processor is not None:
+        return processor(str(full_path), action, self)
 
 
 def create(
@@ -340,12 +412,12 @@ class Pooch:
 
         """
         self._assert_file_in_registry(fname)
+        full_path = self.abspath / fname
+        url = self.get_url(fname)
 
         # Create the local data directory if it doesn't already exist
         os.makedirs(str(self.abspath), exist_ok=True)
 
-        full_path = self.abspath / fname
-        url = self.get_url(fname)
         in_storage = full_path.exists()
 
         if not in_storage:

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -20,14 +20,7 @@ from .utils import (
     os_cache,
     unique_file_name,
 )
-from .downloaders import HTTPDownloader, FTPDownloader
-
-
-KNOWN_DOWNLOADERS = {
-    "ftp": FTPDownloader,
-    "https": HTTPDownloader,
-    "http": HTTPDownloader,
-}
+from .downloaders import choose_downloader
 
 
 def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=None):
@@ -81,14 +74,7 @@ def _download_if_needed(
         )
 
         if downloader is None:
-            parsed_url = parse_url(url)
-            if parsed_url["protocol"] not in KNOWN_DOWNLOADERS:
-                raise ValueError(
-                    "Unrecognized URL protocol '{}' in '{}'. Must be one of {}.".format(
-                        parsed_url["protocol"], url, KNOWN_DOWNLOADERS.keys()
-                    )
-                )
-            downloader = KNOWN_DOWNLOADERS[parsed_url["protocol"]]()
+            downloader = choose_downloader(url)
 
         # Stream the file to a temporary so that we can safely check its hash
         # before overwriting the original

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -109,9 +109,9 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
     >>> url = "https://github.com/fatiando/pooch/raw/{}/data/tiny-data.txt"
     >>> url = url.format(check_version(version.full_version))
     >>> # Download the file and save it locally. Will check the MD5 checksum of
-    >>> # the downloaded file against the given value to make it's the right
-    >>> # file. You can use other hashes by specifying different algorithm
-    >>> # names (sha256, sha1, etc).
+    >>> # the downloaded file against the given value to make sure it's the
+    >>> # right file. You can use other hashes by specifying different
+    >>> # algorithm names (sha256, sha1, etc).
     >>> fname = retrieve(
     ...     url, known_hash="md5:70e2afd3fd7e336ae478b1e740a5f08e",
     ... )

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -174,6 +174,7 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
     ... )
     >>> print(os.path.splitext(fname)[1])
     .zip
+    >>> os.remove(fname)
     >>> # Using the processor, the archive will be unzipped and a list with the
     >>> # path to every file will be returned instead of a single path.
     >>> fnames = retrieve(
@@ -188,7 +189,6 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
     ...     print(f.read().strip())
     # A tiny data file for test purposes only
     1  2  3  4  5  6
-    >>> os.remove(fname)
     >>> for f in fnames:
     ...     os.remove(f)
 
@@ -221,7 +221,7 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
                 "Use this value as the 'known_hash' argument of 'pooch.retrieve'"
                 " to ensure that the file hasn't changed if it is downloaded again"
                 " in the future.",
-                file_hash(full_path),
+                file_hash(str(full_path)),
             )
 
     if processor is not None:
@@ -416,7 +416,7 @@ class Pooch:
     @property
     def abspath(self):
         "Absolute path to the local storage"
-        return Path(str(self.path)).expanduser().resolve()
+        return Path(os.path.abspath(os.path.expanduser(str(self.path))))
 
     @property
     def registry_files(self):

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -73,7 +73,7 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
         full the path, just the file name (it will be appended to *path*). If
         None, will create a unique file name using a combination of the last
         part of the URL (assuming it's the file name) and the MD5 hash of the
-        URL. For example, ``81whdo2d2e928yd1wi22:data-file.csv``. This ensures
+        URL. For example, ``81whdo2d2e928yd1wi22-data-file.csv``. This ensures
         that files from different URLs never overwrite each other, even if they
         have the same name.
     path : str or PathLike or None

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -3,7 +3,9 @@ Download hooks for Pooch.fetch
 """
 import sys
 import ftplib
+
 import requests
+
 from .utils import parse_url
 
 
@@ -11,6 +13,51 @@ try:
     from tqdm import tqdm
 except ImportError:
     tqdm = None
+
+
+def choose_downloader(url):
+    """
+    Choose the appropriate downloader for the given URL based on the protocol.
+
+    Parameters
+    ----------
+    url : str
+        A URL (including protocol).
+
+    Returns
+    -------
+    downloader
+        A downloader class (either :class:`pooch.HTTPDownloader` or
+        :class:`pooch.FTPDownloader`).
+
+    Examples
+    --------
+
+    >>> downloader = choose_downloader("http://something.com")
+    >>> print(downloader.__class__.__name__)
+    HTTPDownloader
+    >>> downloader = choose_downloader("https://something.com")
+    >>> print(downloader.__class__.__name__)
+    HTTPDownloader
+    >>> downloader = choose_downloader("ftp://something.com")
+    >>> print(downloader.__class__.__name__)
+    FTPDownloader
+
+    """
+    known_downloaders = {
+        "ftp": FTPDownloader,
+        "https": HTTPDownloader,
+        "http": HTTPDownloader,
+    }
+    parsed_url = parse_url(url)
+    if parsed_url["protocol"] not in known_downloaders:
+        raise ValueError(
+            "Unrecognized URL protocol '{}' in '{}'. Must be one of {}.".format(
+                parsed_url["protocol"], url, known_downloaders.keys()
+            )
+        )
+    downloader = known_downloaders[parsed_url["protocol"]]()
+    return downloader
 
 
 class HTTPDownloader:  # pylint: disable=too-few-public-methods

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -41,7 +41,7 @@ def test_retrieve():
             fname = retrieve(url, known_hash=None, path=local_store)
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert os.path.abspath(local_store) in logs
+            assert os.path.abspath(os.path.expanduser(local_store)) in logs
             assert "SHA256 hash of downloaded file:" in logs
             assert REGISTRY[data_file] in logs
         # Check that the downloaded file has the right content
@@ -67,7 +67,7 @@ def test_retrieve_fname():
             fname = retrieve(url, known_hash=None, path=local_store, fname=data_file)
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert os.path.abspath(local_store) in logs
+            assert os.path.abspath(os.path.expanduser(local_store)) in logs
             assert "SHA256 hash of downloaded file:" in logs
             assert REGISTRY[data_file] in logs
         # Check that the downloaded file has the right name and content

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -56,7 +56,9 @@ def test_retrieve():
         assert file_hash(fname) == REGISTRY[data_file]
         # Check that no logging happens when not downloading
         with capture_log() as log_file:
-            fname = retrieve(url, file_hash=file_hash(fname), fname=data_file, path=path)
+            fname = retrieve(
+                url, file_hash=file_hash(fname), fname=data_file, path=path
+            )
             assert log_file.getvalue() == ""
 
 

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -41,7 +41,7 @@ def test_retrieve():
             fname = retrieve(url, known_hash=None, path=local_store)
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert local_store in logs
+            assert os.path.abspath(local_store) in logs
             assert "SHA256 hash of downloaded file:" in logs
             assert REGISTRY[data_file] in logs
         # Check that the downloaded file has the right content
@@ -67,7 +67,7 @@ def test_retrieve_fname():
             fname = retrieve(url, known_hash=None, path=local_store, fname=data_file)
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert local_store in logs
+            assert os.path.abspath(local_store) in logs
             assert "SHA256 hash of downloaded file:" in logs
             assert REGISTRY[data_file] in logs
         # Check that the downloaded file has the right name and content

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -80,7 +80,7 @@ def test_retrieve_default_path():
     "Try downloading some data with retrieve to the default cache location"
     data_file = "tiny-data.txt"
     url = BASEURL + data_file
-    expected_location = (os_cache("pooch") / data_file).resolve()
+    expected_location = os_cache("pooch") / data_file
     try:
         # Check that the logs say that the file is being downloaded
         with capture_log() as log_file:
@@ -91,7 +91,7 @@ def test_retrieve_default_path():
             assert "SHA256 hash of downloaded file" in logs
             assert REGISTRY[data_file] in logs
         # Check that the downloaded file has the right content
-        assert fname == str(expected_location)
+        assert fname == str(expected_location.resolve())
         check_tiny_data(fname)
         assert file_hash(fname) == REGISTRY[data_file]
     finally:

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -83,7 +83,7 @@ def test_pooch_custom_url():
             fname = pup.fetch("tiny-data.txt")
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert logs.split()[-1] == "'{}'.".format(path)
+            assert logs.split()[-1] == "{}".format(path)
         check_tiny_data(fname)
         # Check that no logging happens when there are no events
         with capture_log() as log_file:
@@ -103,7 +103,7 @@ def test_pooch_download():
             fname = pup.fetch("tiny-data.txt")
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert logs.split()[-1] == "'{}'.".format(path)
+            assert logs.split()[-1] == "{}".format(path)
         # Check that the downloaded file has the right content
         assert true_path == fname
         check_tiny_data(fname)
@@ -144,7 +144,7 @@ def test_pooch_update():
             fname = pup.fetch("tiny-data.txt")
             logs = log_file.getvalue()
             assert logs.split()[0] == "Updating"
-            assert logs.split()[-1] == "'{}'.".format(path)
+            assert logs.split()[-1] == "{}".format(path)
         # Check that the updated file has the right content
         assert true_path == fname
         check_tiny_data(fname)
@@ -166,7 +166,7 @@ def test_pooch_corrupted():
                 pup.fetch("tiny-data.txt")
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert logs.split()[-1] == "'{}'.".format(path)
+            assert logs.split()[-1] == "{}".format(path)
     # and the case where the file exists but hash doesn't match
     pup = Pooch(path=DATA_DIR, base_url=BASEURL, registry=REGISTRY_CORRUPTED)
     with capture_log() as log_file:
@@ -174,7 +174,7 @@ def test_pooch_corrupted():
             pup.fetch("tiny-data.txt")
         logs = log_file.getvalue()
         assert logs.split()[0] == "Updating"
-        assert logs.split()[-1] == "'{}'.".format(DATA_DIR)
+        assert logs.split()[-1] == "{}".format(DATA_DIR)
 
 
 def test_pooch_file_not_in_registry():
@@ -293,9 +293,9 @@ def test_downloader(capsys):
             fname = pup.fetch("large-data.txt", downloader=download)
             logs = log_file.getvalue()
             lines = logs.splitlines()
-            assert len(lines) == 2
+            assert len(lines) == 4
             assert lines[0].split()[0] == "Downloading"
-            assert lines[1] == "downloader executed"
+            assert lines[-1] == "downloader executed"
         # Read stderr and make sure no progress bar was printed by default
         assert not capsys.readouterr().err
         # Check that the downloaded file has the right content

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -41,7 +41,6 @@ def test_retrieve():
             fname = retrieve(url, known_hash=None, path=local_store)
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert os.path.abspath(os.path.expanduser(local_store)) in logs
             assert "SHA256 hash of downloaded file:" in logs
             assert REGISTRY[data_file] in logs
         # Check that the downloaded file has the right content
@@ -67,7 +66,6 @@ def test_retrieve_fname():
             fname = retrieve(url, known_hash=None, path=local_store, fname=data_file)
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert os.path.abspath(os.path.expanduser(local_store)) in logs
             assert "SHA256 hash of downloaded file:" in logs
             assert REGISTRY[data_file] in logs
         # Check that the downloaded file has the right name and content

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -165,7 +165,7 @@ def test_pooch_load_registry():
     "Loading the registry from a file should work"
     pup = Pooch(path="", base_url="")
     pup.load_registry(os.path.join(DATA_DIR, "registry.txt"))
-    assert pup.registry == Pooch.add_hash_algs(REGISTRY)
+    assert pup.registry == REGISTRY
     assert pup.registry_files.sort() == list(REGISTRY).sort()
 
 
@@ -177,14 +177,14 @@ def test_pooch_load_registry_fileobj():
     pup = Pooch(path="", base_url="")
     with open(path, "rb") as fin:
         pup.load_registry(fin)
-    assert pup.registry == Pooch.add_hash_algs(REGISTRY)
+    assert pup.registry == REGISTRY
     assert pup.registry_files.sort() == list(REGISTRY).sort()
 
     # Text mode
     pup = Pooch(path="", base_url="")
     with open(path, "r") as fin:
         pup.load_registry(fin)
-    assert pup.registry == Pooch.add_hash_algs(REGISTRY)
+    assert pup.registry == REGISTRY
     assert pup.registry_files.sort() == list(REGISTRY).sort()
 
 
@@ -192,7 +192,7 @@ def test_pooch_load_registry_custom_url():
     "Load the registry from a file with a custom URL inserted"
     pup = Pooch(path="", base_url="")
     pup.load_registry(os.path.join(DATA_DIR, "registry-custom-url.txt"))
-    assert pup.registry == Pooch.add_hash_algs(REGISTRY)
+    assert pup.registry == REGISTRY
     assert pup.urls == {"tiny-data.txt": "https://some-site/tiny-data.txt"}
 
 

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -35,10 +35,10 @@ def test_decompress(method, ext):
             fname = pup.fetch("tiny-data.txt." + ext, processor=processor)
             logs = log_file.getvalue()
             lines = logs.splitlines()
-            assert len(lines) == 2
+            assert len(lines) == 4
             assert lines[0].split()[0] == "Downloading"
-            assert lines[1].startswith("Decompressing")
-            assert method in lines[1]
+            assert lines[-1].startswith("Decompressing")
+            assert method in lines[-1]
         assert fname == true_path
         check_tiny_data(fname)
         # Check that processor doesn't execute when not downloading
@@ -100,9 +100,9 @@ def test_processors(proc_cls, ext):
             assert len(fnames) == 1
             logs = log_file.getvalue()
             lines = logs.splitlines()
-            assert len(lines) == 2
+            assert len(lines) == 4
             assert lines[0].split()[0] == "Downloading"
-            assert lines[1].startswith("Extracting 'tiny-data.txt'")
+            assert lines[-1].startswith("Extracting 'tiny-data.txt'")
 
         assert fname == true_path
         check_tiny_data(fname)
@@ -139,9 +139,9 @@ def test_processor_multiplefiles(proc_cls, ext, msg):
             fnames = pup.fetch("store" + ext, processor=processor)
             logs = log_file.getvalue()
             lines = logs.splitlines()
-            assert len(lines) == 2
+            assert len(lines) == 4
             assert lines[0].split()[0] == "Downloading"
-            assert lines[1].startswith("{} contents".format(msg))
+            assert lines[-1].startswith("{} contents".format(msg))
             assert len(fnames) == 2
             assert true_paths == set(fnames)
             for fname in fnames:

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -16,6 +16,7 @@ from ..utils import (
     make_local_storage,
     file_hash,
     hash_matches,
+    unique_file_name,
 )
 from .utils import check_tiny_data, capture_log
 
@@ -27,6 +28,16 @@ REGISTRY_RECURSIVE = (
     "subdir/tiny-data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d\n"
     "tiny-data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d\n"
 )
+
+
+def test_unique_name_long():
+    "The file name should never be longer than 255 characters"
+    url = "https://www.something.com/data{}.txt".format("a" * 500)
+    assert len(url) > 255
+    fname = unique_file_name(url)
+    assert len(fname) == 255
+    assert fname[-10:] == "aaaaaa.txt"
+    assert fname.split(":")[1][:10] == "aaaaaaaaaa"
 
 
 def test_local_storage_makedirs_permissionerror(monkeypatch):

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -38,7 +38,7 @@ def test_unique_name_long():
     fname = unique_file_name(url)
     assert len(fname) == 255
     assert fname[-10:] == "aaaaaa.txt"
-    assert fname.split(":")[1][:10] == "aaaaaaaaaa"
+    assert fname.split("-")[1][:10] == "aaaaaaaaaa"
 
 
 def test_local_storage_makedirs_permissionerror(monkeypatch):

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -90,10 +90,10 @@ def file_hash(fname, alg="sha256"):
     >>> os.remove(fname)
 
     """
-    # Calculate the hash in chunks to avoid overloading the memory
-    chunksize = 65536
     if alg not in hashlib.algorithms_available:
         raise ValueError("Algorithm '{}' not available in hashlib".format(alg))
+    # Calculate the hash in chunks to avoid overloading the memory
+    chunksize = 65536
     hasher = hashlib.new(alg)
     with open(fname, "rb") as fin:
         buff = fin.read(chunksize)
@@ -305,3 +305,25 @@ def hash_algorithm(hash_string):
     else:
         algorithm = parts[0]
     return algorithm
+
+
+def hash_matches(fname, known_hash):
+    """
+    Check if the hash of a file matches a known hash.
+
+    Parameters
+    ----------
+    fname : str or PathLike
+        The path to the file.
+    known_hash : str
+        The known hash. Optionally, prepend ``alg:`` to the hash to specify the
+        hashing algorithm. Default is SHA256.
+
+    Returns
+    -------
+    is_same : bool
+        True if the hash matches, False otherwise.
+
+    """
+    new_hash = file_hash(fname, alg=hash_algorithm(known_hash))
+    return new_hash == known_hash.split(":")[-1]

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -277,7 +277,8 @@ def hash_algorithm(hash_string):
     The hash string should have the following form ``algorithm:hash``, where
     algorithm can be the name of any algorithm known to :mod:`hashlib`.
 
-    If the algorithm is omitted, will default to ``"sha256"``.
+    If the algorithm is omitted or the hash string is None, will default to
+    ``"sha256"``.
 
     Parameters
     ----------
@@ -298,13 +299,17 @@ def hash_algorithm(hash_string):
     md5
     >>> print(hash_algorithm("sha256:qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
     sha256
+    >>> print(hash_algorithm(None))
+    sha256
 
     """
-    parts = hash_string.split(":")
-    if len(parts) == 1:
-        algorithm = "sha256"
+    default = "sha256"
+    if hash_string is None:
+        algorithm = default
+    elif ":" not in hash_string:
+        algorithm = default
     else:
-        algorithm = parts[0]
+        algorithm = hash_string.split(":")[0]
     return algorithm
 
 

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -366,5 +366,8 @@ def unique_file_name(url):
     """
     md5 = hashlib.md5(url.encode()).hexdigest()
     fname = parse_url(url)["path"].split("/")[-1]
-    unique_name = "{}:{}".format(md5, fname[::-1][:255 - len(md5) - 1][::-1])
+    # Crop the start of the file name to fit 255 characters including the hash
+    # and the :
+    fname = fname[-(255 - len(md5) - 1) :]
+    unique_name = "{}:{}".format(md5, fname)
     return unique_name

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -267,3 +267,41 @@ def make_local_storage(path, env=None, version=None):
 
         get_logger().warning(message, *args)
     return Path(path)
+
+
+def hash_algorithm(hash_string):
+    """
+    Parse the name of the hash method from the hash string.
+
+    The hash string should have the following form ``algorithm:hash``, where
+    algorithm can be the name of any algorithm known to :mod:`hashlib`.
+
+    If the algorithm is omitted, will default to ``"sha256"``.
+
+    Parameters
+    ----------
+    hash_string : str
+        The hash string with optional algorithm prepended.
+
+    Returns
+    -------
+    hash_algorithm : str
+        The name of the algorithm.
+
+    Examples
+    --------
+
+    >>> print(hash_algorithm("qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
+    sha256
+    >>> print(hash_algorithm("md5:qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
+    md5
+    >>> print(hash_algorithm("sha256:qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
+    sha256
+
+    """
+    parts = hash_string.split(":")
+    if len(parts) == 1:
+        algorithm = "sha256"
+    else:
+        algorithm = parts[0]
+    return algorithm

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -393,7 +393,7 @@ def unique_file_name(url):
     hash (hex digest) of the URL. The name will also include the last portion
     of the URL.
 
-    The format will be: ``{md5}:{filename}.{ext}``
+    The format will be: ``{md5}-{filename}.{ext}``
 
     The file name will be cropped so that the entire name (including the hash)
     is less than 255 characters long (the limit on most file systems).
@@ -412,11 +412,11 @@ def unique_file_name(url):
     --------
 
     >>> print(unique_file_name("https://www.some-server.org/2020/data.txt"))
-    02ddee027ce5ebb3d7059fb23d210604:data.txt
+    02ddee027ce5ebb3d7059fb23d210604-data.txt
     >>> print(unique_file_name("https://www.some-server.org/2019/data.txt"))
-    9780092867b497fca6fc87d8308f1025:data.txt
+    9780092867b497fca6fc87d8308f1025-data.txt
     >>> print(unique_file_name("https://www.some-server.org/2020/data.txt.gz"))
-    181a9d52e908219c2076f55145d6a344:data.txt.gz
+    181a9d52e908219c2076f55145d6a344-data.txt.gz
 
     """
     md5 = hashlib.md5(url.encode()).hexdigest()
@@ -424,5 +424,5 @@ def unique_file_name(url):
     # Crop the start of the file name to fit 255 characters including the hash
     # and the :
     fname = fname[-(255 - len(md5) - 1) :]
-    unique_name = "{}:{}".format(md5, fname)
+    unique_name = "{}-{}".format(md5, fname)
     return unique_name

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -327,3 +327,22 @@ def hash_matches(fname, known_hash):
     """
     new_hash = file_hash(fname, alg=hash_algorithm(known_hash))
     return new_hash == known_hash.split(":")[-1]
+
+
+def make_unique_file_name(url):
+    """
+    Create a unique file name based on the given url.
+
+    Will use the last part of the url and the MD5 checksum of the url to create
+    the file name.
+
+    Parameters
+    ----------
+    url : str
+        The url.
+    
+    Returns
+    -------
+    fname : str
+        
+    """


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->
Add the function `retrieve` for downloading single data files. This is much more convenient than setting up a `Pooch`. It automatically selects a unique file name and saves files to a "pooch" cache (as determined by `os_cache`). Allows passing in `known_hash=None` to bypass the hash checks. In this case, will print a message with the SHA256 hash of the downloaded file and advising users to set `known_hash` to this value.

Fixes #147 




**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
