### PR TITLE
Move downloader choice to a separate function

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -18,13 +18,7 @@ from .utils import (
     hash_algorithm,
     hash_matches,
 )
-from .downloaders import HTTPDownloader, FTPDownloader
-
-KNOWN_DOWNLOADERS = {
-    "ftp": FTPDownloader,
-    "https": HTTPDownloader,
-    "http": HTTPDownloader,
-}
+from .downloaders import choose_downloader
 
 
 def create(
@@ -365,16 +359,9 @@ class Pooch:
                 str(self.path),
             )
 
-            parsed_url = parse_url(url)
-            if parsed_url["protocol"] not in KNOWN_DOWNLOADERS:
-                raise ValueError(
-                    "Unrecognized URL protocol '{}' in '{}'. Must be one of {}.".format(
-                        parsed_url["protocol"], url, KNOWN_DOWNLOADERS.keys()
-                    )
-                )
-
             if downloader is None:
-                downloader = KNOWN_DOWNLOADERS[parsed_url["protocol"]]()
+                downloader = choose_downloader(url)
+
             # Stream the file to a temporary so that we can safely check its
             # hash before overwriting the original
             tmp = tempfile.NamedTemporaryFile(delete=False, dir=str(self.abspath))

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -13,6 +13,51 @@ except ImportError:
     tqdm = None
 
 
+def choose_downloader(url):
+    """
+    Choose the appropriate downloader for the given URL based on the protocol.
+
+    Parameters
+    ----------
+    url : str
+        A URL (including protocol).
+
+    Returns
+    -------
+    downloader
+        A downloader class (either :class:`pooch.HTTPDownloader` or
+        :class:`pooch.FTPDownloader`).
+
+    Examples
+    --------
+
+    >>> downloader = choose_downloader("http://something.com")
+    >>> print(downloader.__class__.__name__)
+    HTTPDownloader
+    >>> downloader = choose_downloader("https://something.com")
+    >>> print(downloader.__class__.__name__)
+    HTTPDownloader
+    >>> downloader = choose_downloader("ftp://something.com")
+    >>> print(downloader.__class__.__name__)
+    FTPDownloader
+
+    """
+    known_downloaders = {
+        "ftp": FTPDownloader,
+        "https": HTTPDownloader,
+        "http": HTTPDownloader,
+    }
+    parsed_url = parse_url(url)
+    if parsed_url["protocol"] not in known_downloaders:
+        raise ValueError(
+            "Unrecognized URL protocol '{}' in '{}'. Must be one of {}.".format(
+                parsed_url["protocol"], url, known_downloaders.keys()
+            )
+        )
+    downloader = known_downloaders[parsed_url["protocol"]]()
+    return downloader
+
+
 class HTTPDownloader:  # pylint: disable=too-few-public-methods
     """
     Download manager for fetching files over HTTP/HTTPS.

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -1,0 +1,104 @@
+"""
+Test the downloader classes and functions separately from the Pooch core.
+"""
+import os
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+try:
+    import tqdm
+except ImportError:
+    tqdm = None
+
+from ..downloaders import HTTPDownloader, FTPDownloader, choose_downloader
+
+from .utils import (
+    pooch_test_url,
+    pooch_test_registry,
+    check_large_data,
+)
+
+# FTP doesn't work on Travis CI so need to be able to skip tests there
+ON_TRAVIS = bool(os.environ.get("TRAVIS", None))
+DATA_DIR = str(Path(__file__).parent / "data")
+REGISTRY = pooch_test_registry()
+BASEURL = pooch_test_url()
+REGISTRY_CORRUPTED = {
+    # The same data file but I changed the hash manually to a wrong one
+    "tiny-data.txt": "098h0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d"
+}
+
+
+def test_unsupported_protocol():
+    "Should raise ValueError when protocol not in {'https', 'http', 'ftp'}"
+    with pytest.raises(ValueError):
+        choose_downloader("httpup://some-invalid-url.com")
+
+
+# https://blog.travis-ci.com/2018-07-23-the-tale-of-ftp-at-travis-ci
+@pytest.mark.skipif(ON_TRAVIS, reason="FTP is not allowed on Travis CI")
+def test_ftp_downloader():
+    "Test ftp downloader"
+    with TemporaryDirectory() as local_store:
+        downloader = FTPDownloader()
+        url = "ftp://speedtest.tele2.net/100KB.zip"
+        outfile = os.path.join(local_store, "100KB.zip")
+        downloader(url, outfile, None)
+        assert os.path.exists(outfile)
+
+
+@pytest.mark.skipif(tqdm is not None, reason="tqdm must be missing")
+@pytest.mark.parametrize("downloader", [HTTPDownloader, FTPDownloader])
+def test_downloader_progressbar_fails(downloader):
+    "Make sure an error is raised if trying to use progressbar without tqdm"
+    with pytest.raises(ValueError):
+        downloader(progressbar=True)
+
+
+@pytest.mark.skipif(tqdm is None, reason="requires tqdm")
+def test_downloader_progressbar(capsys):
+    "Setup a downloader function that prints a progress bar for fetch"
+    download = HTTPDownloader(progressbar=True)
+    with TemporaryDirectory() as local_store:
+        fname = "large-data.txt"
+        url = BASEURL + fname
+        outfile = os.path.join(local_store, "large-data.txt")
+        download(url, outfile, None)
+        # Read stderr and make sure the progress bar is printed only when told
+        captured = capsys.readouterr()
+        printed = captured.err.split("\r")[-1].strip()
+        assert len(printed) == 79
+        if sys.platform == "win32":
+            progress = "100%|####################"
+        else:
+            progress = "100%|████████████████████"
+        # Bar size is not always the same so can't reliably test the whole bar.
+        assert printed[:25] == progress
+        # Check that the downloaded file has the right content
+        check_large_data(outfile)
+
+
+@pytest.mark.skipif(tqdm is None, reason="requires tqdm")
+@pytest.mark.skipif(ON_TRAVIS, reason="FTP is not allowed on Travis CI")
+def test_downloader_progressbar_ftp(capsys):
+    "Setup an FTP downloader function that prints a progress bar for fetch"
+    download = FTPDownloader(progressbar=True)
+    with TemporaryDirectory() as local_store:
+        url = "ftp://speedtest.tele2.net/100KB.zip"
+        outfile = os.path.join(local_store, "100KB.zip")
+        download(url, outfile, None)
+        # Read stderr and make sure the progress bar is printed only when told
+        captured = capsys.readouterr()
+        printed = captured.err.split("\r")[-1].strip()
+        assert len(printed) == 79
+        if sys.platform == "win32":
+            progress = "100%|####################"
+        else:
+            progress = "100%|████████████████████"
+        # Bar size is not always the same so can't reliably test the whole bar.
+        assert printed[:25] == progress
+        # Check that the file was actually downloaded
+        assert os.path.exists(outfile)

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -3,7 +3,6 @@ Test the downloader classes and functions separately from the Pooch core.
 """
 import os
 import sys
-from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -14,22 +13,12 @@ except ImportError:
     tqdm = None
 
 from ..downloaders import HTTPDownloader, FTPDownloader, choose_downloader
+from .utils import pooch_test_url, check_large_data
 
-from .utils import (
-    pooch_test_url,
-    pooch_test_registry,
-    check_large_data,
-)
 
 # FTP doesn't work on Travis CI so need to be able to skip tests there
 ON_TRAVIS = bool(os.environ.get("TRAVIS", None))
-DATA_DIR = str(Path(__file__).parent / "data")
-REGISTRY = pooch_test_registry()
 BASEURL = pooch_test_url()
-REGISTRY_CORRUPTED = {
-    # The same data file but I changed the hash manually to a wrong one
-    "tiny-data.txt": "098h0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d"
-}
 
 
 def test_unsupported_protocol():


### PR DESCRIPTION
The code that chooses the appropriate downloader for the given url
doesn't depend on anything else in `pooch/core.py`. Move it to
`pooch/downloaders.py` to test it separately from the `Pooch` class and
avoid importing downloaders at all in `pooch/core.py`. Move the
downloader specific tests to a separate file as well so it matches the
tests for processors better (in a separate file instead of in the core
tests).


Taken from #152 




**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
