### PR TITLE
Move all hash checking to hash_matches

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -10,12 +10,10 @@ import ftplib
 
 import requests
 from .utils import (
-    file_hash,
     check_version,
     parse_url,
     get_logger,
     make_local_storage,
-    hash_algorithm,
     hash_matches,
 )
 from .downloaders import choose_downloader

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -163,3 +163,29 @@ def test_hash_matches():
     for alg in ("sha512", "md5"):
         known_hash = "{}:p98oh2dl2j2h2p8e9yfho3fi2e9fhd".format(alg)
         assert not hash_matches(fname, known_hash)
+
+
+def test_hash_matches_strict():
+    "Make sure the hash checking function raises an exception if strict"
+    fname = os.path.join(DATA_DIR, "tiny-data.txt")
+    check_tiny_data(fname)
+    with open(fname, "rb") as fin:
+        data = fin.read()
+    # Check if the check passes
+    hasher = hashlib.new("sha256")
+    hasher.update(data)
+    known_hash = "{}".format(hasher.hexdigest())
+    assert hash_matches(fname, known_hash, strict=True)
+    for alg in ("sha512", "md5"):
+        hasher = hashlib.new(alg)
+        hasher.update(data)
+        known_hash = "{}:{}".format(alg, hasher.hexdigest())
+        assert hash_matches(fname, known_hash, strict=True)
+    # And also if it fails
+    bad_hash = "p98oh2dl2j2h2p8e9yfho3fi2e9fhd"
+    with pytest.raises(ValueError):
+        hash_matches(fname, bad_hash, strict=True)
+    for alg in ("sha512", "md5"):
+        bad_hash = "{}:p98oh2dl2j2h2p8e9yfho3fi2e9fhd".format(alg)
+        with pytest.raises(ValueError):
+            hash_matches(fname, bad_hash, strict=True)

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -307,7 +307,7 @@ def hash_algorithm(hash_string):
     return algorithm
 
 
-def hash_matches(fname, known_hash):
+def hash_matches(fname, known_hash, strict=False):
     """
     Check if the hash of a file matches a known hash.
 
@@ -318,6 +318,9 @@ def hash_matches(fname, known_hash):
     known_hash : str
         The known hash. Optionally, prepend ``alg:`` to the hash to specify the
         hashing algorithm. Default is SHA256.
+    strict : bool
+        If True, will raise a :class:`ValueError` if the hash does not match
+        informing the user that the file may be corrupted.
 
     Returns
     -------
@@ -326,4 +329,13 @@ def hash_matches(fname, known_hash):
 
     """
     new_hash = file_hash(fname, alg=hash_algorithm(known_hash))
-    return new_hash == known_hash.split(":")[-1]
+    matches = new_hash == known_hash.split(":")[-1]
+    if not matches:
+        raise ValueError(
+            "{} hash of file '{}' does not match the known hash:"
+            " expected '{}' but got '{}'. "
+            " The file may be corrupted or the known hash may be outdated.".format(
+                fname, known_hash, new_hash,
+            )
+        )
+    return matches

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -328,14 +328,15 @@ def hash_matches(fname, known_hash, strict=False):
         True if the hash matches, False otherwise.
 
     """
-    new_hash = file_hash(fname, alg=hash_algorithm(known_hash))
+    algorithm = hash_algorithm(known_hash)
+    new_hash = file_hash(fname, alg=algorithm)
     matches = new_hash == known_hash.split(":")[-1]
-    if not matches:
+    if strict and not matches:
         raise ValueError(
             "{} hash of file '{}' does not match the known hash:"
             " expected '{}' but got '{}'. "
             " The file may be corrupted or the known hash may be outdated.".format(
-                fname, known_hash, new_hash,
+                algorithm.upper(), fname, known_hash, new_hash,
             )
         )
     return matches


### PR DESCRIPTION
Including the exception raising controlled by new parameter `strict`.
This removes the need for re-calculating the new hash just so we can
include it in the error message. The hash calculation can be heavy
for large files so we don't want to do it twice. Also improve the error
message to include the hash algorithm and suggest what went wrong.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Working towards #152 




**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
