### PR TITLE
Don't use temp file name in hash mismatch error

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -518,5 +518,5 @@ def stream_download(url, fname, known_hash, downloader, pooch=None):
     # before overwriting the original.
     with temporary_file(path=str(fname.parent)) as tmp:
         downloader(url, tmp, pooch)
-        hash_matches(tmp, known_hash, strict=True, url=url)
+        hash_matches(tmp, known_hash, strict=True, source=str(fname.name))
         shutil.move(tmp, str(fname))

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -518,5 +518,5 @@ def stream_download(url, fname, known_hash, downloader, pooch=None):
     # before overwriting the original.
     with temporary_file(path=str(fname.parent)) as tmp:
         downloader(url, tmp, pooch)
-        hash_matches(tmp, known_hash, strict=True)
+        hash_matches(tmp, known_hash, strict=True, url=url)
         shutil.move(tmp, str(fname))

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -131,16 +131,18 @@ def test_pooch_corrupted():
         path = os.path.abspath(local_store)
         pup = Pooch(path=path, base_url=BASEURL, registry=REGISTRY_CORRUPTED)
         with capture_log() as log_file:
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError) as error:
                 pup.fetch("tiny-data.txt")
+            assert "(tiny-data.txt)" in str(error.value)
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
             assert logs.split()[-1] == "'{}'.".format(path)
     # and the case where the file exists but hash doesn't match
     pup = Pooch(path=DATA_DIR, base_url=BASEURL, registry=REGISTRY_CORRUPTED)
     with capture_log() as log_file:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as error:
             pup.fetch("tiny-data.txt")
+        assert "(tiny-data.txt)" in str(error.value)
         logs = log_file.getvalue()
         assert logs.split()[0] == "Updating"
         assert logs.split()[-1] == "'{}'.".format(DATA_DIR)

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -185,12 +185,13 @@ def test_hash_matches_strict():
     # And also if it fails
     bad_hash = "p98oh2dl2j2h2p8e9yfho3fi2e9fhd"
     with pytest.raises(ValueError) as error:
-        hash_matches(fname, bad_hash, strict=True, url="Neverland")
+        hash_matches(fname, bad_hash, strict=True, source="Neverland")
     assert "Neverland" in str(error.value)
     for alg in ("sha512", "md5"):
         bad_hash = "{}:p98oh2dl2j2h2p8e9yfho3fi2e9fhd".format(alg)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as error:
             hash_matches(fname, bad_hash, strict=True)
+        assert fname in str(error.value)
 
 
 def test_temporary_file():

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -184,8 +184,9 @@ def test_hash_matches_strict():
         assert hash_matches(fname, known_hash, strict=True)
     # And also if it fails
     bad_hash = "p98oh2dl2j2h2p8e9yfho3fi2e9fhd"
-    with pytest.raises(ValueError):
-        hash_matches(fname, bad_hash, strict=True)
+    with pytest.raises(ValueError) as error:
+        hash_matches(fname, bad_hash, strict=True, url="Neverland")
+    assert "Neverland" in str(error.value)
     for alg in ("sha512", "md5"):
         bad_hash = "{}:p98oh2dl2j2h2p8e9yfho3fi2e9fhd".format(alg)
         with pytest.raises(ValueError):

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -310,7 +310,7 @@ def hash_algorithm(hash_string):
     return algorithm
 
 
-def hash_matches(fname, known_hash, strict=False, url="URL not provided"):
+def hash_matches(fname, known_hash, strict=False, source=None):
     """
     Check if the hash of a file matches a known hash.
 
@@ -324,10 +324,11 @@ def hash_matches(fname, known_hash, strict=False, url="URL not provided"):
     strict : bool
         If True, will raise a :class:`ValueError` if the hash does not match
         informing the user that the file may be corrupted.
-    url : str
-        The download URL for *fname*. Will be used in the error message if
-        *strict* is True. Has no other use other than reporting to the user
-        where the file came from in case of hash mismatch.
+    source : str
+        The source of the downloaded file (name or URL, for example). Will be
+        used in the error message if *strict* is True. Has no other use other
+        than reporting to the user where the file came from in case of hash
+        mismatch. If None, will default to *fname*.
 
     Returns
     -------
@@ -339,12 +340,14 @@ def hash_matches(fname, known_hash, strict=False, url="URL not provided"):
     new_hash = file_hash(fname, alg=algorithm)
     matches = new_hash == known_hash.split(":")[-1]
     if strict and not matches:
+        if source is None:
+            source = str(fname)
         raise ValueError(
             "{} hash of downloaded file ({}) does not match the known hash:"
             " expected {} but got {}. Deleted download for safety."
             " The downloaded file may have been corrupted or"
             " the known hash may be outdated.".format(
-                algorithm.upper(), url, known_hash, new_hash,
+                algorithm.upper(), source, known_hash, new_hash,
             )
         )
     return matches

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -310,7 +310,7 @@ def hash_algorithm(hash_string):
     return algorithm
 
 
-def hash_matches(fname, known_hash, strict=False):
+def hash_matches(fname, known_hash, strict=False, url="URL not provided"):
     """
     Check if the hash of a file matches a known hash.
 
@@ -324,6 +324,10 @@ def hash_matches(fname, known_hash, strict=False):
     strict : bool
         If True, will raise a :class:`ValueError` if the hash does not match
         informing the user that the file may be corrupted.
+    url : str
+        The download URL for *fname*. Will be used in the error message if
+        *strict* is True. Has no other use other than reporting to the user
+        where the file came from in case of hash mismatch.
 
     Returns
     -------
@@ -336,10 +340,11 @@ def hash_matches(fname, known_hash, strict=False):
     matches = new_hash == known_hash.split(":")[-1]
     if strict and not matches:
         raise ValueError(
-            "{} hash of file '{}' does not match the known hash:"
-            " expected '{}' but got '{}'. "
-            " The file may be corrupted or the known hash may be outdated.".format(
-                algorithm.upper(), fname, known_hash, new_hash,
+            "{} hash of downloaded file ({}) does not match the known hash:"
+            " expected {} but got {}. Deleted download for safety."
+            " The downloaded file may have been corrupted or"
+            " the known hash may be outdated.".format(
+                algorithm.upper(), url, known_hash, new_hash,
             )
         )
     return matches


### PR DESCRIPTION
Fixes a regression introduced in #157 where we started including the
name of the temporary download file in the exception again. Revert back
to including the name of the file in the registry.
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
