### PR TITLE
Add example to create registry from remote files

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -743,7 +743,7 @@ registry:
             url=base_url + fname, known_hash=None, fname=fname, path=directory
         )
 
-    # Create the registry file
+    # Create the registry file from the downloaded data files
     pooch.make_registry("data_files", "registry.txt")
 
 If each data file has its own url, the registry file can be manually created

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -753,8 +753,8 @@ after downloading each data file through :func:`pooch.retrieve`:
 
     import os
 
-    # Names and urls of the data files
-    # (file names are only used for naming the downloaded files)
+    # Names and urls of the data files. The file names are used for naming the 
+    # downloaded files. These are the names that will be included in the registry.
     fnames_and_urls = {
         "c137.csv": "https://www.some-data-hosting-site.com/c137/data.csv",
         "cronen.csv": "https://www.some-data-hosting-site.com/cronen/data.csv",

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -714,10 +714,10 @@ Create registry file from remote files
 --------------------------------------
 
 If you want to create a registry file for a large number of data files that are
-available for download but you don't have either its hashes nor any local copy
-of them, you must download them first. Manually downloading each one of them
-can be tedious. However, we can automatically download each data file through
-:func:`pooch.retrieve` and then create the registry file.
+available for download but you don't have their hashes or any local copies, 
+you must download them first. Manually downloading each file
+can be tedious. However, we can automate the process using
+:func:`pooch.retrieve`. Below, we'll explore two different scenarios.
 
 If the data files share the same base url, we can use :func:`pooch.retrieve`
 to download them and then use :func:`pooch.make_registry` to create the

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -768,7 +768,7 @@ after downloading each data file through :func:`pooch.retrieve`:
     # Create a new registry file
     with open("registry.txt", "w") as registry:
         for fname, url in fnames_and_urls.items():
-            # Download each data file to the pooch cache directory
+            # Download each data file to the specified directory
             path = pooch.retrieve(
                 url=url, known_hash=None, fname=fname, path=directory
             )

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -772,7 +772,7 @@ after downloading each data file through :func:`pooch.retrieve`:
             path = pooch.retrieve(
                 url=url, known_hash=None, fname=fname, path=directory
             )
-            # Add file name, its hash and its url to the new registry file
+            # Add the name, hash, and url of the file to the new registry file
             registry.write(
                 "{} {} {}\n".format(fname, pooch.file_hash(path), url)
             )

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -776,3 +776,10 @@ after downloading each data file through :func:`pooch.retrieve`:
             registry.write(
                 "{} {} {}\n".format(fname, pooch.file_hash(path), url)
             )
+            
+.. warning::
+    
+    Notice that there are **no checks for download integrity** (since we don't know the
+    file hashes before hand). Only do this for trusted data sources and over a secure 
+    connection. If you have access to file hashes/checksums, **we highly recommend
+    using them** to set the ``known_hash`` argument. 


### PR DESCRIPTION
Add example for creating a registry file from remote files using the
`pooch.retrieve` function. The examples covers two cases: when all remote files
share the same base url and when every file has its own url.

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.