### PR TITLE
Added skimage to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,7 @@ For **package developers** including sample data in their projects:
 Projects using Pooch
 --------------------
 
+* `scikit-image <https://github.com/scikit-image/scikit-image>`__
 * `MetPy <https://github.com/Unidata/MetPy>`__
 * `Verde <https://github.com/fatiando/verde>`__
 * `Harmonica <https://github.com/fatiando/harmonica>`__


### PR DESCRIPTION
We have recently switched to `pooch` as our backend for data management - https://github.com/scikit-image/scikit-image/pull/3945. Proposing to add a note on `scikit-image` as one of the libraries using `pooch`.