### PR TITLE
Bug fix: creating the cache folder in parallel

### DIFF
--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -63,7 +63,7 @@ def test_make_local_storage_parallel(pool, monkeypatch):
 
     def mockmakedirs(path, exist_ok=False):  # pylint: disable=unused-argument
         "Delay before calling makedirs"
-        time.sleep(0.5)
+        time.sleep(1.5)
         makedirs(path, exist_ok=exist_ok)
 
     monkeypatch.setattr(os, "makedirs", mockmakedirs)

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -2,10 +2,13 @@
 Test the utility functions.
 """
 import os
+import shutil
 import hashlib
+import time
 from pathlib import Path
 import tempfile
 from tempfile import NamedTemporaryFile, TemporaryDirectory
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 
 import pytest
 
@@ -39,6 +42,45 @@ def test_unique_name_long():
     assert len(fname) == 255
     assert fname[-10:] == "aaaaaa.txt"
     assert fname.split("-")[1][:10] == "aaaaaaaaaa"
+
+
+@pytest.mark.parametrize(
+    "pool", [ThreadPoolExecutor, ProcessPoolExecutor], ids=["threads", "processes"],
+)
+def test_make_local_storage_parallel(pool, monkeypatch):
+    "Try to create the cache folder in parallel"
+    # Can cause multiple attempts at creating the folder which leads to an
+    # exception. Check that this doesn't happen.
+    # See https://github.com/fatiando/pooch/issues/170
+
+    # Monkey path makedirs to make it delay before creating the directory.
+    # Otherwise, the dispatch is too fast and the directory will exist before
+    # another process tries to create it.
+
+    # Need to keep a reference to the original function to avoid infinite
+    # recursions from the monkey patching.
+    makedirs = os.makedirs
+
+    def mockmakedirs(path, exist_ok=False):  # pylint: disable=unused-argument
+        "Delay before calling makedirs"
+        time.sleep(0.5)
+        makedirs(path, exist_ok=exist_ok)
+
+    monkeypatch.setattr(os, "makedirs", mockmakedirs)
+
+    data_cache = os.path.join(os.curdir, "test_parallel_cache")
+    assert not os.path.exists(data_cache)
+
+    try:
+        with pool() as executor:
+            futures = [
+                executor.submit(make_local_storage, data_cache) for i in range(4)
+            ]
+            for future in futures:
+                assert os.path.exists(str(future.result()))
+    finally:
+        if os.path.exists(data_cache):
+            shutil.rmtree(data_cache)
 
 
 def test_local_storage_makedirs_permissionerror(monkeypatch):

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -253,6 +253,9 @@ def make_local_storage(path, env=None, version=None):
     try:
         if not os.path.exists(path):
             action = "create"
+            # When running in parallel, it's possible that multiple jobs will
+            # try to create the path at the same time. Use exist_ok to avoid
+            # raising an error.
             os.makedirs(path)
         else:
             action = "write to"

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -256,7 +256,7 @@ def make_local_storage(path, env=None, version=None):
             # When running in parallel, it's possible that multiple jobs will
             # try to create the path at the same time. Use exist_ok to avoid
             # raising an error.
-            os.makedirs(path)
+            os.makedirs(path, exist_ok=True)
         else:
             action = "write to"
             with tempfile.NamedTemporaryFile(dir=path):

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -262,6 +262,12 @@ def make_local_storage(path, env=None, version=None):
             with tempfile.NamedTemporaryFile(dir=path):
                 pass
     except PermissionError:
+        # Only log an error message instead of raising an exception. The cache
+        # is usually created at import time, so raising an exception here would
+        # cause packages to crash immediately, even if users aren't using the
+        # sample data at all. So issue a warning here just in case and only
+        # crash with an exception when the user actually tries to download
+        # data (Pooch.fetch or retrieve).
         message = (
             "Cannot %s data cache folder '%s'. "
             "Will not be able to download remote data files. "


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Add `exist_ok` to `os.makedirs` in case the cache folder is being created in parallel (multiple jobs trying to call `makedirs` at the same time). Includes a test case with threads and processes to make sure it works.

Fixes #170 and fixes #150




**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
