### PR TITLE
Delay cache creation until download

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -309,6 +309,9 @@ def create(
     ...              registry={"data.txt": "9081wo2eb2gc0u..."})
     >>> print(pup.path.parts)  # The path is a pathlib.Path
     ('myproject', 'v0.1')
+    >>> # The local folder is only created when a dataset is first downloaded
+    >>> print(pup.path.exists())
+    False
     >>> print(pup.base_url)
     http://some.link.com/v0.1/
     >>> print(pup.registry)

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -255,8 +255,8 @@ def create(
     ``https://github.com/fatiando/pooch/raw/v0.1/data``). If the version string
     contains ``+XX.XXXXX``, it will be interpreted as a development version.
 
-    Does **not** create the local data storage folder if it doesn't exist. The
-    folder will only be created the first time a download is attempted with
+    Does **not** create the local data storage folder. The folder will only be
+    created the first time a download is attempted with
     :meth:`pooch.Pooch.fetch`. This makes it safe to use this function at the
     module level (so it's executed on ``import`` and the resulting
     :class:`~pooch.Pooch` is a global variable).

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -13,6 +13,7 @@ from .utils import (
     parse_url,
     get_logger,
     make_local_storage,
+    cache_location,
     hash_matches,
     temporary_file,
     os_cache,
@@ -200,7 +201,8 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
         fname = unique_file_name(url)
     # Create the local data directory if it doesn't already exist and make the
     # path absolute.
-    path = make_local_storage(path, env=None, version=None).resolve()
+    path = cache_location(path, env=None, version=None).resolve()
+    make_local_storage(path)
 
     full_path = path / fname
     action, verb = download_action(full_path, known_hash)
@@ -368,7 +370,7 @@ def create(
     if version is not None:
         version = check_version(version, fallback=version_dev)
         base_url = base_url.format(version=version)
-    path = make_local_storage(path, env, version)
+    path = cache_location(path, env, version)
     pup = Pooch(path=path, base_url=base_url, registry=registry, urls=urls)
     return pup
 
@@ -545,7 +547,7 @@ class Pooch:
         self._assert_file_in_registry(fname)
 
         # Create the local data directory if it doesn't already exist
-        os.makedirs(str(self.abspath), exist_ok=True)
+        make_local_storage(str(self.abspath))
 
         url = self.get_url(fname)
         full_path = self.abspath / fname

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -255,6 +255,12 @@ def create(
     ``https://github.com/fatiando/pooch/raw/v0.1/data``). If the version string
     contains ``+XX.XXXXX``, it will be interpreted as a development version.
 
+    Does **not** create the local data storage folder if it doesn't exist. The
+    folder will only be created the first time a download is attempted with
+    :meth:`pooch.Pooch.fetch`. This makes it safe to use this function at the
+    module level (so it's executed on ``import`` and the resulting
+    :class:`~pooch.Pooch` is a global variable).
+
     Parameters
     ----------
     path : str, PathLike, list or tuple
@@ -373,6 +379,11 @@ def create(
     if version is not None:
         version = check_version(version, fallback=version_dev)
         base_url = base_url.format(version=version)
+    # Don't create the cache folder here! This function is usually called in
+    # the module context (at import time), so touching the file system is not
+    # recommended. It could cause crashes when multiple processes/threads try
+    # to import at the same time (which would try to create the folder several
+    # times at once).
     path = cache_location(path, env, version)
     pup = Pooch(path=path, base_url=base_url, registry=registry, urls=urls)
     return pup

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -201,10 +201,10 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
         fname = unique_file_name(url)
     # Create the local data directory if it doesn't already exist and make the
     # path absolute.
-    path = cache_location(path, env=None, version=None).resolve()
+    path = cache_location(path, env=None, version=None)
     make_local_storage(path)
 
-    full_path = path / fname
+    full_path = path.resolve() / fname
     action, verb = download_action(full_path, known_hash)
 
     if action in ("download", "update"):

--- a/pooch/tests/test_integration.py
+++ b/pooch/tests/test_integration.py
@@ -13,7 +13,7 @@ from .utils import check_tiny_data, capture_log
 
 def test_create_and_fetch():
     "Fetch a data file from the local storage"
-    path = os_cache("pooch-testing").resolve()
+    path = os_cache("pooch-testing")
     if path.exists():
         shutil.rmtree(str(path))
     pup = create(

--- a/pooch/tests/test_integration.py
+++ b/pooch/tests/test_integration.py
@@ -6,35 +6,27 @@ import os
 import shutil
 from pathlib import Path
 
-import pytest
-
 from .. import create, os_cache
 from ..version import full_version
 from .utils import check_tiny_data, capture_log
 
 
-@pytest.fixture
-def pup():
-    "Create a pooch the way most projects would."
-    doggo = create(
-        path=os_cache("pooch"),
+def test_create_and_fetch():
+    "Fetch a data file from the local storage"
+    path = os_cache("pooch-testing").resolve()
+    if path.exists():
+        shutil.rmtree(str(path))
+    pup = create(
+        path=path,
         base_url="https://github.com/fatiando/pooch/raw/{version}/data/",
         version=full_version,
         version_dev="master",
         env="POOCH_DATA_DIR",
     )
-    # The str conversion is needed in Python 3.5
-    doggo.load_registry(str(Path(os.path.dirname(__file__), "data", "registry.txt")))
-    if os.path.exists(str(doggo.abspath)):
-        shutil.rmtree(str(doggo.abspath))
-    yield doggo
-    shutil.rmtree(str(doggo.abspath))
-
-
-def test_fetch(pup):
-    "Fetch a data file from the local storage"
-    # Make sure the storage has been cleaned up before running the tests
+    # Make sure the storage isn't created until a download is required
     assert not pup.abspath.exists()
+    # The str conversion is needed in Python 3.5
+    pup.load_registry(str(Path(os.path.dirname(__file__), "data", "registry.txt")))
     for target in ["tiny-data.txt", "subdir/tiny-data.txt"]:
         with capture_log() as log_file:
             fname = pup.fetch(target)

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -77,7 +77,8 @@ def test_make_local_storage_parallel(pool, monkeypatch):
                 executor.submit(make_local_storage, data_cache) for i in range(4)
             ]
             for future in futures:
-                assert os.path.exists(str(future.result()))
+                future.result()
+            assert os.path.exists(data_cache)
     finally:
         if os.path.exists(data_cache):
             shutil.rmtree(data_cache)
@@ -97,7 +98,7 @@ def test_local_storage_makedirs_permissionerror(monkeypatch):
 
     with capture_log() as log_file:
         make_local_storage(
-            path=data_cache, version="1.0", env="SOME_VARIABLE",
+            path=data_cache, env="SOME_VARIABLE",
         )
         logs = log_file.getvalue()
         assert logs.startswith("Cannot create data cache")
@@ -121,7 +122,7 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
 
         with capture_log() as log_file:
             make_local_storage(
-                path=data_cache, version="1.0", env="SOME_VARIABLE",
+                path=data_cache, env="SOME_VARIABLE",
             )
             logs = log_file.getvalue()
             assert logs.startswith("Cannot write to data cache")

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -22,7 +22,7 @@ from ..utils import (
     temporary_file,
     unique_file_name,
 )
-from .utils import check_tiny_data, capture_log
+from .utils import check_tiny_data
 
 DATA_DIR = str(Path(__file__).parent / "data" / "store")
 REGISTRY = (

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -96,13 +96,12 @@ def test_local_storage_makedirs_permissionerror(monkeypatch):
 
     monkeypatch.setattr(os, "makedirs", mockmakedirs)
 
-    with capture_log() as log_file:
+    with pytest.raises(PermissionError) as error:
         make_local_storage(
             path=data_cache, env="SOME_VARIABLE",
         )
-        logs = log_file.getvalue()
-        assert logs.startswith("Cannot create data cache")
-        assert "'SOME_VARIABLE'" in logs
+        assert "Pooch could not create data cache" in str(error)
+        assert "'SOME_VARIABLE'" in str(error)
 
 
 def test_local_storage_newfile_permissionerror(monkeypatch):
@@ -120,13 +119,12 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
 
         monkeypatch.setattr(tempfile, "NamedTemporaryFile", mocktempfile)
 
-        with capture_log() as log_file:
+        with pytest.raises(PermissionError) as error:
             make_local_storage(
                 path=data_cache, env="SOME_VARIABLE",
             )
-            logs = log_file.getvalue()
-            assert logs.startswith("Cannot write to data cache")
-            assert "'SOME_VARIABLE'" in logs
+            assert "Pooch could not write to data cache" in str(error)
+            assert "'SOME_VARIABLE'" in str(error)
 
 
 def test_registry_builder():

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -278,22 +278,19 @@ def make_local_storage(path, env=None):
             action = "write to"
             with tempfile.NamedTemporaryFile(dir=path):
                 pass
-    except PermissionError:
-        # Only log an error message instead of raising an exception. The cache
-        # is usually created at import time, so raising an exception here would
-        # cause packages to crash immediately, even if users aren't using the
-        # sample data at all. So issue a warning here just in case and only
-        # crash with an exception when the user actually tries to download
-        # data (Pooch.fetch or retrieve).
-        message = (
-            "Cannot %s data cache folder '%s'. "
-            "Will not be able to download remote data files. "
-        )
-        args = [action, path]
+    except PermissionError as error:
+        message = [
+            str(error),
+            "| Pooch could not {} data cache folder '{}'.".format(action, path),
+            "Will not be able to download data files.",
+        ]
         if env is not None:
-            message += "Use environment variable '%s' to specify another directory."
-            args += [env]
-        get_logger().warning(message, *args)
+            message.append(
+                "Use environment variable '{}' to specify a different location.".format(
+                    env
+                )
+            )
+        raise PermissionError(" ".join(message)) from error
 
 
 def hash_algorithm(hash_string):

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -216,11 +216,12 @@ def parse_url(url):
     return {"protocol": protocol, "netloc": parsed_url.netloc, "path": parsed_url.path}
 
 
-def make_local_storage(path, env=None, version=None):
+def cache_location(path, env=None, version=None):
     """
-    Create the local cache directory and make sure it's writable.
+    Location of the cache given a base path and optional configuration.
 
-    If the directory doesn't exist, it will be created.
+    Checks for the environment variable to overwrite the path of the local
+    cache. Optionally add *version* to the path if given.
 
     Parameters
     ----------
@@ -249,6 +250,22 @@ def make_local_storage(path, env=None, version=None):
     if version is not None:
         path = os.path.join(str(path), version)
     path = os.path.expanduser(str(path))
+    return Path(path)
+
+
+def make_local_storage(path, env=None):
+    """
+    Create the local cache directory and make sure it's writable.
+
+    Parameters
+    ----------
+    path : str or PathLike
+        The path to the local data storage folder.
+    env : str or None
+        An environment variable that can be used to overwrite *path*. Only used
+        in the error message in case the folder is not writable.
+    """
+    path = str(path)
     # Check that the data directory is writable
     try:
         if not os.path.exists(path):
@@ -276,9 +293,7 @@ def make_local_storage(path, env=None, version=None):
         if env is not None:
             message += "Use environment variable '%s' to specify another directory."
             args += [env]
-
         get_logger().warning(message, *args)
-    return Path(path)
 
 
 def hash_algorithm(hash_string):


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->
As seen in recent issues in scikit-image, creating the cache folder in `pooch.create` can cause problems since this function is called at import time by our users. This means that importing the package in parallel can cause race conditions and crashes. To prevent that from happening, delay the creation of the cache folder until `Pooch.fetch` or `retrieve` are called. Creating the folder name was factored out of `make_local_storage` into the new function `cache_location`. Both `fetch` and `retrieve` then use `make_local_storage` to create the folder while `create` only runs `cache_location`. Since we can't check if the cache is writable when calling `create`, then it makes more sense to raise an exception with the message about using the environment variable instead of a log message (as #150 wanted).

Fixes #172 




**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [x] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
