### PR TITLE
Fix FTP availability check when file in directory

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -681,12 +681,12 @@ class Pooch:
         source = self.get_url(fname)
         parsed_url = parse_url(source)
         if parsed_url["protocol"] == "ftp":
-            directory = os.path.dirname(parsed_url["path"])
+            directory, file_name = os.path.split(parsed_url["path"])
             ftp = ftplib.FTP()
             ftp.connect(host=parsed_url["netloc"])
             try:
                 ftp.login()
-                available = parsed_url["path"] in ftp.nlst(directory)
+                available = file_name in ftp.nlst(directory)
             finally:
                 ftp.close()
         else:

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -295,13 +295,13 @@ def test_check_availability_on_ftp():
     # Check available remote file on FTP server
     pup = Pooch(
         path=DATA_DIR,
-        base_url="ftp://speedtest.tele2.net/",
+        base_url="ftp://data-out.unavco.org/pub/products/velocity/rel_201712/",
         registry={
-            "100KB.zip": "f627ca4c2c322f15db26152df306bd4f983f0146409b81a4341b9b340c365a16",
+            "pbo.final_igs08.20171202.vel": "md5:0b75d4049dedd0e179615f4b5e956156",
             "doesnot_exist.zip": "jdjdjdjdflld",
         },
     )
-    assert pup.is_available("100KB.zip")
+    assert pup.is_available("pbo.final_igs08.20171202.vel")
     # Check non available remote file
     assert not pup.is_available("doesnot_exist.zip")
 


### PR DESCRIPTION
If the data file is not in the base directory, the `Pooch.is_available` test was broken since we were checking for the full path in `ftp.nlst` instead of just the file name. Using the UNAVCO ftp server revealed this (ftp://data-out.unavco.org/). The change was made since the one we were using before started refusing connections on CI.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
