### PR TITLE
Test FTP downloads using a local test server

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -103,7 +103,7 @@ jobs:
         python.version: '3.5'
         PYTHON: '3.5'
         # Need to use sphinx=2.0.0 because 2.2.0 crashes
-        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx=2.0.0 sphinx_rtd_theme=0.4.3"
+        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov pytest-localftpserver coverage sphinx=2.0.0 sphinx_rtd_theme=0.4.3"
         CONDA_REQUIREMENTS_DEV: ""
 
   steps:
@@ -199,7 +199,7 @@ jobs:
         python.version: '3.5'
         PYTHON: '3.5'
         # Need to use sphinx=2.0.0 because 2.2.0 crashes
-        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov coverage sphinx=2.0.0 sphinx_rtd_theme=0.4.3"
+        CONDA_INSTALL_EXTRA: "codecov pip pytest pytest-cov pytest-localftpserver coverage sphinx=2.0.0 sphinx_rtd_theme=0.4.3"
         CONDA_REQUIREMENTS_DEV: ""
 
   steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
           env:
               - PYTHON=3.5
               # Need to use sphinx=2.0.0 because 2.2.0 crashes
-              - CONDA_INSTALL_EXTRA="codecov pip pytest pytest-cov coverage sphinx=2.0.0 sphinx_rtd_theme=0.4.3"
+              - CONDA_INSTALL_EXTRA="codecov pip pytest pytest-cov pytest-localftpserver coverage sphinx=2.0.0 sphinx_rtd_theme=0.4.3"
               - CONDA_REQUIREMENTS_DEV=""
 
 # Setup the build environment

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
     # Development requirements
     - pytest
     - pytest-cov
+    - pytest-localftpserver
     - coverage
     - black
     - flake8

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -284,6 +284,9 @@ class FTPDownloader:  # pylint: disable=too-few-public-methods
             ftp.login(user=self.username, passwd=self.password, acct=self.account)
             command = "RETR {}".format(parsed_url["path"])
             if self.progressbar:
+                # Make sure the file is set to binary mode, otherwise we can't
+                # get the file size. See: https://stackoverflow.com/a/22093848
+                ftp.voidcmd("TYPE I")
                 size = int(ftp.size(parsed_url["path"]))
                 use_ascii = bool(sys.platform == "win32")
                 progress = tqdm(

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -16,8 +16,6 @@ from ..downloaders import HTTPDownloader, FTPDownloader, choose_downloader
 from .utils import pooch_test_url, check_large_data, check_tiny_data, data_over_ftp
 
 
-# FTP doesn't work on Travis CI so need to be able to skip tests there
-ON_TRAVIS = bool(os.environ.get("TRAVIS", None))
 BASEURL = pooch_test_url()
 
 
@@ -27,8 +25,6 @@ def test_unsupported_protocol():
         choose_downloader("httpup://some-invalid-url.com")
 
 
-# https://blog.travis-ci.com/2018-07-23-the-tale-of-ftp-at-travis-ci
-# @pytest.mark.skipif(ON_TRAVIS, reason="FTP is not allowed on Travis CI")
 def test_ftp_downloader(ftpserver):
     "Test ftp downloader"
     with data_over_ftp(ftpserver, "tiny-data.txt") as url:
@@ -70,7 +66,6 @@ def test_downloader_progressbar(capsys):
         check_large_data(outfile)
 
 
-# @pytest.mark.skipif(ON_TRAVIS, reason="FTP is not allowed on Travis CI")
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")
 def test_downloader_progressbar_ftp(capsys, ftpserver):
     "Setup an FTP downloader function that prints a progress bar for fetch"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # Development requirements
 pytest
 pytest-cov
+pytest-localftpserver
 coverage
 sphinx==2.2.1
 sphinx_rtd_theme==0.4.3


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Using the `pytest-localftpserver` plugin, we can test FTP downloads running on a local server. The nice thing is that the plugin just provides a fixture that can access the server so we don't have to do much. Added a context manager to move test files to the local server and clean up afterwards. The availability test is still relying on a remote server because the local server runs on a random port and we don't have a way to control that on `Pooch.is_available` yet (see #191).

Fixes #190 

This is waiting on #191 at the moment. 




**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [x] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
