### PR TITLE
Add GitHub Actions workflow for publishing to PyPI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,6 +67,18 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          # Need to fetch more than the last commit so that versioneer can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version still be wrong.
+          # Increase if necessary.
+          fetch-depth: 100
+
+      # Need the tags so that versioneer can form a valid version number
+      - name: Fetch git tags
+        run: |
+          git fetch origin 'refs/tags/*:refs/tags/*'
+          git tag --list
 
       - name: Setup caching for conda packages
         uses: actions/cache@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,9 +76,7 @@ jobs:
 
       # Need the tags so that versioneer can form a valid version number
       - name: Fetch git tags
-        run: |
-          git fetch origin 'refs/tags/*:refs/tags/*'
-          git tag --list
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup caching for conda packages
         uses: actions/cache@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,16 +1,17 @@
 # Configuration for testing and deploying with GitHub Actions
-name: Test
+name: test
 
-# Only build PRs, the master branch, and release tags. Pushes to branches will
-# only be built when a PR is opened. This avoids duplicated buids in PRs
-# comming from branches in the origin repository (1 for PR and 1 for push).
+# Only build PRs, the master branch, and releases. Pushes to branches will only
+# be built when a PR is opened. This avoids duplicated buids in PRs comming
+# from branches in the origin repository (1 for PR and 1 for push).
 on:
   pull_request:
   push:
     branches:
       - master
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  release:
+    types:
+      - published
 
 # Use bash by default in all jobs
 defaults:
@@ -18,9 +19,9 @@ defaults:
     # The -l {0} is necessary for conda environments to be activated
     shell: bash -l {0}
 
-###############################################################################
 jobs:
 
+  #############################################################################
   # Run tests, build the docs, and deploy if needed
   test:
     name: ${{ matrix.os }} py${{ matrix.python }} ${{ matrix.dependencies }}
@@ -66,18 +67,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          # Need to fetch more than the last commit so that versioneer can
-          # create the correct version string. If the number of commits since
-          # the last release is greater than this, the version still be wrong.
-          # Increase if necessary.
-          fetch-depth: 100
-
-      # Need the tags so that versioneer can form a valid version number
-      - name: Fetch git tags
-        run: |
-          git fetch origin 'refs/tags/*:refs/tags/*'
-          git tag --list
 
       - name: Setup caching for conda packages
         uses: actions/cache@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - master
-      # FOR TESTING ONLY! REMOVE BEFORE MERGING
-      - deploy-pypi
   release:
     types:
       - published

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,80 @@
+# Configuration for publishing archives to PyPI and documentation pages to
+# GitHub Pages using GitHub Actions
+name: deploy
+
+# Only run for pushes to the master branch and releases.
+on:
+  push:
+    branches:
+      - master
+      - deploy-pypi
+  release:
+    types:
+      - published
+
+jobs:
+
+  #############################################################################
+  # Publish built wheels and source archives to PyPI and test PyPI
+  pypi:
+    name: PyPI
+    runs-on: ubuntu-latest
+    # Only publish from the origin repository, not forks
+    if: github.repository == 'fatiando/pooch'
+    # Only run after the tests finish successfully
+    needs: test
+
+    steps:
+
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Need to fetch more than the last commit so that versioneer can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version still be wrong.
+          # Increase if necessary.
+          fetch-depth: 100
+
+      # Need the tags so that versioneer can form a valid version number
+      - name: Fetch git tags
+        run: |
+          git fetch origin 'refs/tags/*:refs/tags/*'
+          git tag --list
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Install requirements
+        run: python -m pip install setuptools twine wheel
+
+      - name: List installed packages
+        run: python -m pip freeze
+
+      - name: Build source and wheel distributions
+        run: |
+          python setup.py sdist bdist_wheel
+          echo ""
+          echo "Generated files:"
+          ls -lh dist/
+
+      - name: Check the archives
+        run: twine check dist/*
+
+      - name: Publish to Test PyPI
+        if: success() && github.event_name == 'pull_request'
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN}}
+          repository_url: https://test.pypi.org/legacy/
+
+      #- name: Publish to PyPI
+        ## Only publish to PyPI when a release triggers the build
+        #if: success() && github.event.action == 'published'
+        #uses: pypa/gh-action-pypi-publish@v1
+        #with:
+          #user: __token__
+          #password: ${{ secrets.PYPI_TOKEN}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,9 +75,10 @@ jobs:
           # NOT TO BE USED in PyPI!
           skip_existing: true
 
-      #- name: Publish to PyPI
-        ## Only publish to PyPI when a release triggers the build
+      - name: Publish to PyPI
+        # Only publish to PyPI when a release triggers the build
         #if: success() && github.event.action == 'published'
+        run: echo "YEAH! ${{ github.event_name }}"
         #uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
         #with:
           #user: __token__

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,9 +36,7 @@ jobs:
 
       # Need the tags so that versioneer can form a valid version number
       - name: Fetch git tags
-        run: |
-          git fetch origin 'refs/tags/*:refs/tags/*'
-          git tag --list
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -53,6 +51,11 @@ jobs:
 
       - name: Build source and wheel distributions
         run: |
+          # Change the versioneer format to "pre" so that the commit hash isn't
+          # included (PyPI doesn't allow it). Can't do this permanently because
+          # we rely the hash to indicate to the tests that this is a local
+          # verison instead of a published version.
+          #sed --in-place "s/pep440/pep440-pre/g" setup.cfg
           python setup.py sdist bdist_wheel
           echo ""
           echo "Generated files:"
@@ -77,8 +80,9 @@ jobs:
 
       - name: Publish to PyPI
         # Only publish to PyPI when a release triggers the build
+        if: success()
         #if: success() && github.event.action == 'published'
-        run: echo "YEAH! ${{ github.event_name }}"
+        run: echo "YEAH!"
         #uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
         #with:
           #user: __token__

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
           # included (PyPI doesn't allow it). Can't do this permanently because
           # we rely the hash to indicate to the tests that this is a local
           # verison instead of a published version.
-          #sed --in-place "s/pep440/pep440-pre/g" setup.cfg
+          sed --in-place "s/pep440/pep440-pre/g" setup.cfg
           python setup.py sdist bdist_wheel
           echo ""
           echo "Generated files:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,17 +62,23 @@ jobs:
         run: twine check dist/*
 
       - name: Publish to Test PyPI
-        if: success() && github.event_name == 'pull_request'
-        uses: pypa/gh-action-pypi-publish@v1
+        if: success()
+        # Pin to a specific commit to avoid having the authentication token
+        # stolen if the Action is compromised:
+        # https://github.com/pypa/gh-action-pypi-publish/issues/27#issuecomment-596082795
+        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_TOKEN}}
           repository_url: https://test.pypi.org/legacy/
+          # Allow existing releases on test PyPI without errors.
+          # NOT TO BE USED in PyPI!
+          skip_existing: true
 
       #- name: Publish to PyPI
         ## Only publish to PyPI when a release triggers the build
         #if: success() && github.event.action == 'published'
-        #uses: pypa/gh-action-pypi-publish@v1
+        #uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
         #with:
           #user: __token__
           #password: ${{ secrets.PYPI_TOKEN}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     # Only publish from the origin repository, not forks
     if: github.repository == 'fatiando/pooch'
-    # Only run after the tests finish successfully
-    needs: test
 
     steps:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      # FOR TESTING ONLY! REMOVE BEFORE MERGING
       - deploy-pypi
   release:
     types:
@@ -81,8 +82,7 @@ jobs:
       - name: Publish to PyPI
         # Only publish to PyPI when a release triggers the build
         if: success() && github.event_name == 'release'
-        run: echo "YEAH!"
-        #uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
-        #with:
-          #user: __token__
-          #password: ${{ secrets.PYPI_TOKEN}}
+        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,8 +80,7 @@ jobs:
 
       - name: Publish to PyPI
         # Only publish to PyPI when a release triggers the build
-        if: success()
-        #if: success() && github.event.action == 'published'
+        if: success() && github.event_name == 'release'
         run: echo "YEAH!"
         #uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
         #with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,5 +1,5 @@
 # Linting and style checks with GitHub Actions
-name: Code Style
+name: code-style
 
 # Only build PRs and the master branch. Pushes to branches will only be built
 # when a PR is opened.

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ env:
         # Encrypted variables
         # Github Token for pushing the built HTML (GH_TOKEN)
         - secure: "uWYRnZV4KpElFZBsiw6MPbBERlvMyEdP0IUdp7ys8l5sJHTGppkZC6KOrxo5/xG1pqmu625FOM8+V5CDhqdzsVUedyDuLTD17ma8MkPAliAPKdBFwGkm1Y3nJZMEYVsvff7lM+bz8e4t8vrkLweaRSciJ65v4YRPjUnlDNVjXDLHOAmAB7VsU33ntxQZHByvjJX/3h6NWrbQmNifa7+BSlN2vSpQZFs/0shUJ3noJhessZLoxhylK2dDBt/ug8e8YN/5Hq9cDv6a+q9lac9E2n7dk8kV6xnzoBzddK09hk7PfDbheiHFwjwQGhzjgmth14FTii8U1MyLcZ+F+HGZHRHRMk/ARLfYK3HbioCTNR4fURiKJpoSEk/8mv/qKh6O1qnDWvs1cbEn37G600l8LK6ExEuP1dQlVYYvfhcwCqBVQXG5Z8pfql5p7T/BfLPCwsVAGKWN/g2PpHHHj23vkdEUdyenTGjOD8M+Zdm/Dxz+QnuZiCKVolgt1yx5aHfM1piw07fUq2CHPwLSOZdj4+sDHj8/zyCUUJSaU/I9xzc4BFB2oAxSTVm2kNSj2aqssxbgDu/bgwtaIP5oqCLrCDKNyEjqtXDsYyI+T0YJ67wFdpB1/K1pukYkU9/LCGrDWoUfxejm14MJFYmivpQDAa2heeHFiuVVBEaHzOBgWoE="
-        # PyPI password for deploying releases (TWINE_PASSWORD)
-        - secure: "drOQIoP0IbVf+NbjbyH2nGEixtt4R/1tBQYr7EBjo2IDXI8/b5io7voL2jsaAhhCGZpzaLJvvv1gVUj9FxJFfhiQKwyU2F4n0E1TLJFFVfxXWMUFh6rrCAAbfuBhhzRDsbVNtH29FYPhNJKj8D2YsLkAydoRfMDMli0DJrn0qPO+/My0Dk7ikaPLo1/UDRLSUBae95yGbex3B/ksTZdELIVAZiSb7SWkL//cQpl+UcP/tvAWxsz+XIWH2TJ8d8anOSnZv7ccCkVx1P8DDp1LxhvY3vSiSV9KE3WDTWJzgmuvC34e5sPqxPoQjDklHjCQHtV4p2hi7tNAFX9yESUjSpFS8LDGMgQRrt6s5y3+KmQ4Qg/lJTNnRVIu/L6cxH9NPFd8bmJevQO532Qu8d5aiNmgAQb1/m8ZuEZCebXxXSMTD1Pl+b3xS/folhqyKhh31pLb7JPwhjSTdim08ZjISdRIqNVes2dNYgfqaF7RNrho4ha0Cj7NpRW1YEYw+n0kVjFmZuIoWyNXClfAfn03r69XgXLAh51HmW1OeXrdRr6Ji7sbVLyu5AMkGEt92G9dJARqb+E+hHk4p+5Htp/U7rRzcUsXhMYKaMY4d9D8uCRNNbAFnKqOlOUXq3FaVG/qAi4Y4YskYtHs3veKjnP/TRdIEugFuEZjeaADFLR6YWA="
-        - TWINE_USERNAME=Leonardo.Uieda
         # The file with the listed requirements to be installed by conda
         - CONDA_REQUIREMENTS=requirements.txt
         - CONDA_REQUIREMENTS_DEV=requirements-dev.txt
@@ -36,8 +33,7 @@ matrix:
           env:
               - PYTHON=3.6
               - DEPLOY_DOCS=true
-              - DEPLOY_PYPI=true
-              - CONDA_INSTALL_EXTRA="codecov twine"
+              - CONDA_INSTALL_EXTRA="codecov"
 
 # Setup the build environment
 before_install:
@@ -72,12 +68,6 @@ after_success:
 
 # Deploy
 deploy:
-    # Make a release on PyPI
-    - provider: script
-      script: continuous-integration/travis/deploy-pypi.sh
-      on:
-          tags: true
-          condition: '$DEPLOY_PYPI == "true"'
     # Push the built HTML in doc/_build/html to the gh-pages branch
     - provider: script
       script: continuous-integration/travis/deploy-gh-pages.sh

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [versioneer]
 VCS = git
-style = pep440-pre
+style = pep440
 versionfile_source = pooch/_version.py
 versionfile_build = pooch/_version.py
 tag_prefix = ''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [versioneer]
 VCS = git
-style = pep440
+style = pep440-pre
 versionfile_source = pooch/_version.py
 versionfile_build = pooch/_version.py
 tag_prefix = ''


### PR DESCRIPTION
Use a separate workflow that doesn't run on pull requests. Builds the
archives/wheels and pushes to test PyPI on pushes to the master branch
and to PyPI proper on releases.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
