### PR TITLE
Point to Unzip/tar from Decompress docs and errors

### DIFF
--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -195,15 +195,14 @@ class Decompress:  # pylint: disable=too-few-public-methods
     Supported decompression methods are LZMA (``.xz``), bzip2 (``.bz2``), and
     gzip (``.gz``).
 
-    .. note::
-
-        To unpack zip and tar archives with one or more files, use
-        :class:`pooch.Unzip` and :class:`pooch.Untar` instead. This processor
-        only decompresses single files.
-
     File names with the standard extensions (see above) can use
     ``method="auto"`` to automatically determine the compression method. This
     can be overwritten by setting the *method* argument.
+
+    .. note::
+
+        To unpack zip and tar archives with one or more files, use
+        :class:`pooch.Unzip` and :class:`pooch.Untar` instead.
 
     Parameters
     ----------

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -195,6 +195,12 @@ class Decompress:  # pylint: disable=too-few-public-methods
     Supported decompression methods are LZMA (``.xz``), bzip2 (``.bz2``), and
     gzip (``.gz``).
 
+    .. note::
+
+        To unpack zip and tar archives with one or more files, use
+        :class:`pooch.Unzip` and :class:`pooch.Untar` instead. This processor
+        only decompresses single files.
+
     File names with the standard extensions (see above) can use
     ``method="auto"`` to automatically determine the compression method. This
     can be overwritten by setting the *method* argument.
@@ -207,7 +213,8 @@ class Decompress:  # pylint: disable=too-few-public-methods
 
     """
 
-    modules = {"lzma": lzma, "xz": lzma, "gzip": gzip, "bzip2": bz2}
+    modules = {"auto": None, "lzma": lzma, "xz": lzma, "gzip": gzip, "bzip2": bz2}
+    extensions = {".xz": "lzma", ".gz": "gzip", ".bz2": "bzip2"}
 
     def __init__(self, method="auto"):
         self.method = method
@@ -259,21 +266,22 @@ class Decompress:  # pylint: disable=too-few-public-methods
         extension. If no recognized extension is in the file name, will raise a
         ValueError.
         """
-        method = self.method
-        if method == "auto":
-            ext = os.path.splitext(fname)[-1]
-            valid_methods = {".xz": "lzma", ".gz": "gzip", ".bz2": "bzip2"}
-            if ext not in valid_methods:
-                raise ValueError(
-                    "Unrecognized extension '{}'. Must be one of '{}'.".format(
-                        ext, list(valid_methods.keys())
-                    )
-                )
-            method = valid_methods[ext]
-        if method not in self.modules:
-            raise ValueError(
-                "Invalid compression method '{}'. Must be one of '{}'.".format(
-                    method, list(self.modules.keys())
-                )
+        error_archives = "To unpack zip/tar archives, use pooch.Unzip/Untar instead."
+        if self.method not in self.modules:
+            message = "Invalid compression method '{}'. Must be one of '{}'.".format(
+                self.method, list(self.modules.keys())
             )
-        return self.modules[method]
+            if self.method in {"zip", "tar"}:
+                message = " ".join([message, error_archives])
+            raise ValueError(message)
+        if self.method == "auto":
+            ext = os.path.splitext(fname)[-1]
+            if ext not in self.extensions:
+                message = "Unrecognized file extension '{}'. Must be one of '{}'.".format(
+                    ext, list(self.extensions.keys())
+                )
+                if ext in {".zip", ".tar"}:
+                    message = " ".join([message, error_archives])
+                raise ValueError(message)
+            return self.modules[self.extensions[ext]]
+        return self.modules[self.method]

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -54,15 +54,29 @@ def test_decompress_fails():
     with TemporaryDirectory() as local_store:
         path = Path(local_store)
         pup = Pooch(path=path, base_url=BASEURL, registry=REGISTRY)
+        # Invalid extension
         with pytest.raises(ValueError) as exception:
             with warnings.catch_warnings():
                 pup.fetch("tiny-data.txt", processor=Decompress(method="auto"))
-        assert exception.value.args[0].startswith("Unrecognized extension '.txt'")
+        assert exception.value.args[0].startswith("Unrecognized file extension '.txt'")
+        assert "pooch.Unzip/Untar" not in exception.value.args[0]
         # Should also fail for a bad method name
         with pytest.raises(ValueError) as exception:
             with warnings.catch_warnings():
                 pup.fetch("tiny-data.txt", processor=Decompress(method="bla"))
         assert exception.value.args[0].startswith("Invalid compression method 'bla'")
+        assert "pooch.Unzip/Untar" not in exception.value.args[0]
+        # Point people to Untar and Unzip
+        with pytest.raises(ValueError) as exception:
+            with warnings.catch_warnings():
+                pup.fetch("tiny-data.txt", processor=Decompress(method="zip"))
+        assert exception.value.args[0].startswith("Invalid compression method 'zip'")
+        assert "pooch.Unzip/Untar" in exception.value.args[0]
+        with pytest.raises(ValueError) as exception:
+            with warnings.catch_warnings():
+                pup.fetch("store.zip", processor=Decompress(method="auto"))
+        assert exception.value.args[0].startswith("Unrecognized file extension '.zip'")
+        assert "pooch.Unzip/Untar" in exception.value.args[0]
 
 
 def test_extractprocessor_fails():


### PR DESCRIPTION
If given a `.zip` or `.tar` archive, `Decompress` will now tell users to
use `Unzip` and `Untar` instead. This clears up the confusion around why
`Decompress` doesn't work with zip files. Add a pointer to the
docstring as well.

Fixes #184 
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
