### PR TITLE
Add warning to the docs about dropping Python 3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,13 +12,13 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 .. image:: https://img.shields.io/conda/vn/conda-forge/pooch.svg?style=flat-square
     :alt: Latest version on conda-forge
     :target: https://github.com/conda-forge/pooch-feedstock
-.. image:: https://img.shields.io/github/workflow/status/fatiando/pooch/code-style/master?label=style&style=flat-square   
+.. image:: https://img.shields.io/github/workflow/status/fatiando/pooch/code-style/master?label=style&style=flat-square
     :alt: GitHub workflow status for code style
     :target: https://github.com/fatiando/pooch/actions?query=workflow%3Acode-style
-.. image:: https://img.shields.io/github/workflow/status/fatiando/pooch/test/master?label=test&style=flat-square   
+.. image:: https://img.shields.io/github/workflow/status/fatiando/pooch/test/master?label=test&style=flat-square
     :alt: GitHub workflow status for tests
     :target: https://github.com/fatiando/pooch/actions?query=workflow%3Atest
-.. image:: https://img.shields.io/github/workflow/status/fatiando/pooch/deploy/master?label=deploy&style=flat-square   
+.. image:: https://img.shields.io/github/workflow/status/fatiando/pooch/deploy/master?label=deploy&style=flat-square
     :alt: GitHub workflow status for deployments
     :target: https://github.com/fatiando/pooch/actions?query=workflow%3Adeploy
 .. image:: https://img.shields.io/codecov/c/github/fatiando/pooch/master.svg?style=flat-square
@@ -31,11 +31,9 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
     :alt: Digital Object Identifier for the JOSS paper
     :target: https://doi.org/10.21105/joss.01943
 
-
 .. placeholder-for-doc-index
 
-🚨 **Python 2.7 is no longer supported. Use Pooch <= 0.6.0 if you need 2.7 support.** 🚨
-
+🚨 **Pooch v1.2.0 is the last release that is compatible with Python 3.5.** 🚨
 
 About
 -----

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,16 +6,8 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python >= 3.6** (see the table below for the Python version
-compatibility of Pooch releases).
-
-+----------------+-------------------------------+
-| Python version | Last compatible Pooch release |
-+----------------+-------------------------------+
-| 2.7            | 0.6.0                         |
-+----------------+-------------------------------+
-| 3.5            | 1.2.0                         |
-+----------------+-------------------------------+
+You'll need **Python >= 3.6** (see :ref:`python-versions` if you
+require support for older versions).
 
 We recommend using the
 `Anaconda <https://www.anaconda.com/download>`__
@@ -91,3 +83,20 @@ Python interpreter or Jupyter notebook::
 
     import pooch
     pooch.test()
+
+
+.. _python-versions:
+
+Python version compatibility
+----------------------------
+
+If you require support for older Python versions, please pin Pooch to the
+following releases to ensure compatibility:
+
++----------------+-------------------------------+
+| Python version | Last compatible Pooch release |
++----------------+-------------------------------+
+| 2.7            | 0.6.0                         |
++----------------+-------------------------------+
+| 3.5            | 1.2.0                         |
++----------------+-------------------------------+

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -6,42 +6,31 @@ Installing
 Which Python?
 -------------
 
-You'll need **Python >= 3.5**.
+You'll need **Python >= 3.6** (see the table below for the Python version
+compatibility of Pooch releases).
 
-.. warning::
-
-   **Python 2.7 is no longer supported. Use Pooch <= 0.6.0 if you need 2.7 support.**
++----------------+-------------------------------+
+| Python version | Last compatible Pooch release |
++----------------+-------------------------------+
+| 2.7            | 0.6.0                         |
++----------------+-------------------------------+
+| 3.5            | 1.2.0                         |
++----------------+-------------------------------+
 
 We recommend using the
-`Anaconda Python distribution <https://www.anaconda.com/download>`__
-to ensure you have all dependencies installed and the ``conda`` package manager
-available.
+`Anaconda <https://www.anaconda.com/download>`__
+or `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`__
+Python distributions to ensure you have all dependencies installed and the
+``conda`` package manager available.
 Installing Anaconda does not require administrative rights to your computer and
 doesn't interfere with any other Python installations in your system.
-
-
-Dependencies
-------------
-
-Required:
-
-* `requests <http://docs.python-requests.org/>`__
-* `packaging <https://github.com/pypa/packaging>`__
-* `appdirs <https://github.com/ActiveState/appdirs>`__
-
-Optional:
-
-* `tqdm <https://github.com/tqdm/tqdm>`__: Required to print a download progress bar
-  (see :class:`pooch.HTTPDownloader`).
-* `paramiko <https://github.com/paramiko/paramiko>`__: Required for SFTP downloads
-  (see :class:`pooch.SFTPDownloader`).
 
 
 Installing with conda
 ---------------------
 
-You can install pooch using the `conda package manager <https://conda.io/>`__ that
-comes with the Anaconda distribution::
+You can install pooch using the `conda package manager <https://conda.io/>`__
+that comes with the Anaconda distribution::
 
     conda install pooch --channel conda-forge
 
@@ -52,33 +41,53 @@ Installing with pip
 Alternatively, you can also use the `pip package manager
 <https://pypi.org/project/pip/>`__::
 
-    pip install pooch
+    python -m pip install pooch
 
 
 Installing the latest development version
 -----------------------------------------
 
-You can use ``pip`` to install the latest source from Github::
+You can use ``pip`` to install the latest version of the source code from
+GitHub::
 
-    pip install https://github.com/fatiando/pooch/archive/master.zip
+    python -m pip install --upgrade git+https://github.com/fatiando/pooch
 
-Alternatively, you can clone the git repository locally and install from there::
 
-    git clone https://github.com/fatiando/pooch.git
-    cd pooch
-    pip install .
+Dependencies
+------------
+
+The required dependencies should be installed automatically when you install
+Pooch using ``conda`` or ``pip``. Optional dependencies have to be installed
+manually.
+
+Required:
+
+* `requests <http://docs.python-requests.org/>`__
+* `packaging <https://github.com/pypa/packaging>`__
+* `appdirs <https://github.com/ActiveState/appdirs>`__
+
+Optional:
+
+* `tqdm <https://github.com/tqdm/tqdm>`__: Required to print a download
+  progress bar (see :class:`pooch.HTTPDownloader`).
+* `paramiko <https://github.com/paramiko/paramiko>`__: Required for SFTP
+  downloads (see :class:`pooch.SFTPDownloader`).
 
 
 Testing your install
 --------------------
+
+.. note::
+
+    This step is optional.
 
 We ship a full test suite with the package.
 To run the tests, you'll need to install some extra dependencies first:
 
 * `pytest <https://docs.pytest.org/>`__
 
-After that, you can test your installation by running the following inside a Python
-interpreter::
+After that, you can test your installation by running the following inside a
+Python interpreter or Jupyter notebook::
 
     import pooch
     pooch.test()


### PR DESCRIPTION
Update the README message to say that 1.2.0 is the last to support 3.5.
Add a compatibility table to the Installing page. Some other
improvements to the install instructions (move dependencies to the
bottom and say that they should be installed automatically, add a note
that the testing step is optional, link to Miniconda as well, using
`python -m pip` instead of `pip`, use `git+https://...` instead of the
zip archive to get correct version numbers from versioneer).

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Related to #199 



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
