### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,8 +12,6 @@ name: test
 on:
   pull_request:
   push:
-    branches:
-      - master
   release:
     types:
       - published
@@ -37,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: [3.5, 3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8]
         # If "optional", will install non-required dependencies in the build
         # environment. Otherwise, only required dependencies are installed.
         dependencies: [""]

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,6 +12,8 @@ name: test
 on:
   pull_request:
   push:
+    branches:
+      - master
   release:
     types:
       - published

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -138,7 +138,7 @@ after downloading each data file through :func:`pooch.retrieve`:
             )
             # Add the name, hash, and url of the file to the new registry file
             registry.write(
-                "{} {} {}\n".format(fname, pooch.file_hash(path), url)
+                f"{fname} {pooch.file_hash(path)} {url}\n"
             )
 
 .. warning::

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,11 +51,9 @@ else:
     version = full_version
 
 # These enable substitutions using |variable| in the rst files
-rst_epilog = """
+rst_epilog = f"""
 .. |year| replace:: {year}
-""".format(
-    year=year
-)
+"""
 
 html_last_updated_fmt = "%b %d, %Y"
 html_title = project

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,7 @@ master_doc = "index"
 # General information about the project
 year = datetime.date.today().year
 project = "Pooch"
-copyright = "2018-{}, The Pooch Developers".format(year)
+copyright = f"2018-{year}, The Pooch Developers"
 if len(full_version.split("+")) > 1 or full_version == "unknown":
     version = "dev"
 else:

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -79,7 +79,7 @@ download URLs) by downloading files from one or more remote servers and storing
 them in a local data cache.
 Pooch is written in pure Python and has minimal dependencies.
 It can be easily installed from the Python Package Index (PyPI) and conda-forge
-on a wide range of Python versions: 2.7 (up to Pooch 0.6.0) and from 3.6 to 3.8.
+on a wide range of Python versions: 2.7 (up to Pooch 0.6.0) and from 3.5 to 3.8.
 The integrity of downloads is verified by comparing the file's SHA-256 hash with
 the one stored in the data registry.
 This is also the mechanism used to detect if a file needs to be re-downloaded

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -79,7 +79,7 @@ download URLs) by downloading files from one or more remote servers and storing
 them in a local data cache.
 Pooch is written in pure Python and has minimal dependencies.
 It can be easily installed from the Python Package Index (PyPI) and conda-forge
-on a wide range of Python versions: 2.7 (up to Pooch 0.6.0) and from 3.5 to 3.8.
+on a wide range of Python versions: 2.7 (up to Pooch 0.6.0) and from 3.6 to 3.8.
 The integrity of downloads is verified by comparing the file's SHA-256 hash with
 the one stored in the data registry.
 This is also the mechanism used to detect if a file needs to be re-downloaded

--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -43,7 +43,7 @@ def test(doctest=True, verbose=True, coverage=False):
     if verbose:
         args.append("-vv")
     if coverage:
-        args.append("--cov={}".format(package))
+        args.append(f"--cov={package}")
         args.append("--cov-report=term-missing")
     if doctest:
         args.append("--doctest-modules")

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -207,7 +207,10 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
 
     if action in ("download", "update"):
         get_logger().info(
-            "%s data from '%s' to file '%s'.", verb, url, str(full_path),
+            "%s data from '%s' to file '%s'.",
+            verb,
+            url,
+            str(full_path),
         )
 
         if downloader is None:
@@ -495,7 +498,11 @@ class Pooch:
 
         if action in ("download", "update"):
             get_logger().info(
-                "%s file '%s' from '%s' to '%s'.", verb, fname, url, str(self.abspath),
+                "%s file '%s' from '%s' to '%s'.",
+                verb,
+                fname,
+                url,
+                str(self.abspath),
             )
 
             if downloader is None:

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -569,11 +569,9 @@ class Pooch:
                 elements = line.split()
                 if not len(elements) in [0, 2, 3]:
                     raise OSError(
-                        "Invalid entry in Pooch registry file '{}': "
-                        "expected 2 or 3 elements in line {} but got {}. "
-                        "Offending entry: '{}'".format(
-                            fname, linenum + 1, len(elements), line
-                        )
+                        f"Invalid entry in Pooch registry file '{fname}': "
+                        f"expected 2 or 3 elements in line {linenum + 1} but got "
+                        f"{len(elements)}. Offending entry: '{line}'"
                     )
                 if elements:
                     file_name = elements[0]

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -514,7 +514,7 @@ class Pooch:
         it's not.
         """
         if fname not in self.registry:
-            raise ValueError("File '{}' is not in the registry.".format(fname))
+            raise ValueError(f"File '{fname}' is not in the registry.")
 
     def get_url(self, fname):
         """

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -58,9 +58,8 @@ def choose_downloader(url):
     parsed_url = parse_url(url)
     if parsed_url["protocol"] not in known_downloaders:
         raise ValueError(
-            "Unrecognized URL protocol '{}' in '{}'. Must be one of {}.".format(
-                parsed_url["protocol"], url, known_downloaders.keys()
-            )
+            f"Unrecognized URL protocol '{parsed_url['protocol']}' in '{url}'. "
+            f"Must be one of {known_downloaders.keys()}."
         )
     downloader = known_downloaders[parsed_url["protocol"]]()
     return downloader
@@ -120,7 +119,7 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
     >>> user = "doggo"
     >>> password = "goodboy"
     >>> # httpbin will ask for the user and password we provide in the URL
-    >>> url = "https://httpbin.org/basic-auth/{}/{}".format(user, password)
+    >>> url = f"https://httpbin.org/basic-auth/{user}/{password}"
     >>> # Trying without the login credentials causes an error
     >>> downloader = HTTPDownloader()
     >>> try:
@@ -290,7 +289,7 @@ class FTPDownloader:  # pylint: disable=too-few-public-methods
             output_file = open(output_file, "w+b")
         try:
             ftp.login(user=self.username, passwd=self.password, acct=self.account)
-            command = "RETR {}".format(parsed_url["path"])
+            command = f"RETR {parsed_url['path']}"
             if self.progressbar:
                 # Make sure the file is set to binary mode, otherwise we can't
                 # get the file size. See: https://stackoverflow.com/a/22093848

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -272,8 +272,9 @@ class Decompress:  # pylint: disable=too-few-public-methods
         """
         error_archives = "To unpack zip/tar archives, use pooch.Unzip/Untar instead."
         if self.method not in self.modules:
-            message = "Invalid compression method '{}'. Must be one of '{}'.".format(
-                self.method, list(self.modules.keys())
+            message = (
+                f"Invalid compression method '{self.method}'. "
+                f"Must be one of '{list(self.modules.keys())}'."
             )
             if self.method in {"zip", "tar"}:
                 message = " ".join([message, error_archives])
@@ -281,8 +282,9 @@ class Decompress:  # pylint: disable=too-few-public-methods
         if self.method == "auto":
             ext = os.path.splitext(fname)[-1]
             if ext not in self.extensions:
-                message = "Unrecognized file extension '{}'. Must be one of '{}'.".format(
-                    ext, list(self.extensions.keys())
+                message = (
+                    f"Unrecognized file extension '{ext}'. "
+                    f"Must be one of '{list(self.extensions.keys())}'."
                 )
                 if ext in {".zip", ".tar"}:
                     message = " ".join([message, error_archives])

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -118,7 +118,7 @@ def test_pooch_custom_url():
             fname = pup.fetch("tiny-data.txt")
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert logs.split()[-1] == "'{}'.".format(path)
+            assert logs.split()[-1] == f"'{path}'."
         check_tiny_data(fname)
         # Check that no logging happens when there are no events
         with capture_log() as log_file:
@@ -138,7 +138,7 @@ def test_pooch_download():
             fname = pup.fetch("tiny-data.txt")
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert logs.split()[-1] == "'{}'.".format(path)
+            assert logs.split()[-1] == f"'{path}'."
         # Check that the downloaded file has the right content
         assert true_path == fname
         check_tiny_data(fname)
@@ -179,7 +179,7 @@ def test_pooch_update():
             fname = pup.fetch("tiny-data.txt")
             logs = log_file.getvalue()
             assert logs.split()[0] == "Updating"
-            assert logs.split()[-1] == "'{}'.".format(path)
+            assert logs.split()[-1] == f"'{path}'."
         # Check that the updated file has the right content
         assert true_path == fname
         check_tiny_data(fname)
@@ -202,7 +202,7 @@ def test_pooch_corrupted():
             assert "(tiny-data.txt)" in str(error.value)
             logs = log_file.getvalue()
             assert logs.split()[0] == "Downloading"
-            assert logs.split()[-1] == "'{}'.".format(path)
+            assert logs.split()[-1] == f"'{path}'."
     # and the case where the file exists but hash doesn't match
     pup = Pooch(path=DATA_DIR, base_url=BASEURL, registry=REGISTRY_CORRUPTED)
     with capture_log() as log_file:
@@ -211,7 +211,7 @@ def test_pooch_corrupted():
         assert "(tiny-data.txt)" in str(error.value)
         logs = log_file.getvalue()
         assert logs.split()[0] == "Updating"
-        assert logs.split()[-1] == "'{}'.".format(DATA_DIR)
+        assert logs.split()[-1] == f"'{DATA_DIR}'."
 
 
 def test_pooch_file_not_in_registry():
@@ -252,7 +252,7 @@ def test_pooch_load_registry_fileobj():
 
     # Text mode
     pup = Pooch(path="", base_url="")
-    with open(path, "r") as fin:
+    with open(path) as fin:
         pup.load_registry(fin)
     assert pup.registry == REGISTRY
     assert pup.registry_files.sort() == list(REGISTRY).sort()
@@ -356,7 +356,7 @@ def test_alternative_hashing_algorithms():
     for alg in ("sha512", "md5"):
         hasher = hashlib.new(alg)
         hasher.update(data)
-        registry = {"tiny-data.txt": "{}:{}".format(alg, hasher.hexdigest())}
+        registry = {"tiny-data.txt": f"{alg}:{hasher.hexdigest()}"}
         pup = Pooch(path=DATA_DIR, base_url="some bogus URL", registry=registry)
         assert fname == pup.fetch("tiny-data.txt")
         check_tiny_data(fname)

--- a/pooch/tests/test_integration.py
+++ b/pooch/tests/test_integration.py
@@ -25,8 +25,7 @@ def test_create_and_fetch():
     )
     # Make sure the storage isn't created until a download is required
     assert not pup.abspath.exists()
-    # The str conversion is needed in Python 3.5
-    pup.load_registry(str(Path(os.path.dirname(__file__), "data", "registry.txt")))
+    pup.load_registry(Path(os.path.dirname(__file__), "data", "registry.txt"))
     for target in ["tiny-data.txt", "subdir/tiny-data.txt"]:
         with capture_log() as log_file:
             fname = pup.fetch(target)

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -155,7 +155,7 @@ def test_processor_multiplefiles(proc_cls, ext, msg):
             lines = logs.splitlines()
             assert len(lines) == 2
             assert lines[0].split()[0] == "Downloading"
-            assert lines[-1].startswith("{} contents".format(msg))
+            assert lines[-1].startswith(f"{msg} contents")
             assert len(fnames) == 2
             assert true_paths == set(fnames)
             for fname in fnames:

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -36,7 +36,7 @@ REGISTRY_RECURSIVE = (
 
 def test_unique_name_long():
     "The file name should never be longer than 255 characters"
-    url = "https://www.something.com/data{}.txt".format("a" * 500)
+    url = f"https://www.something.com/data{'a' * 500}.txt"
     assert len(url) > 255
     fname = unique_file_name(url)
     assert len(fname) == 255

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -203,18 +203,18 @@ def test_hash_matches():
     # Check if the check passes
     hasher = hashlib.new("sha256")
     hasher.update(data)
-    known_hash = "{}".format(hasher.hexdigest())
+    known_hash = f"{hasher.hexdigest()}"
     assert hash_matches(fname, known_hash)
     for alg in ("sha512", "md5"):
         hasher = hashlib.new(alg)
         hasher.update(data)
-        known_hash = "{}:{}".format(alg, hasher.hexdigest())
+        known_hash = f"{alg}:{hasher.hexdigest()}"
         assert hash_matches(fname, known_hash)
     # And also if it fails
     known_hash = "p98oh2dl2j2h2p8e9yfho3fi2e9fhd"
     assert not hash_matches(fname, known_hash)
     for alg in ("sha512", "md5"):
-        known_hash = "{}:p98oh2dl2j2h2p8e9yfho3fi2e9fhd".format(alg)
+        known_hash = f"{alg}:p98oh2dl2j2h2p8e9yfho3fi2e9fhd"
         assert not hash_matches(fname, known_hash)
 
 
@@ -227,12 +227,12 @@ def test_hash_matches_strict():
     # Check if the check passes
     hasher = hashlib.new("sha256")
     hasher.update(data)
-    known_hash = "{}".format(hasher.hexdigest())
+    known_hash = f"{hasher.hexdigest()}"
     assert hash_matches(fname, known_hash, strict=True)
     for alg in ("sha512", "md5"):
         hasher = hashlib.new(alg)
         hasher.update(data)
-        known_hash = "{}:{}".format(alg, hasher.hexdigest())
+        known_hash = f"{alg}:{hasher.hexdigest()}"
         assert hash_matches(fname, known_hash, strict=True)
     # And also if it fails
     bad_hash = "p98oh2dl2j2h2p8e9yfho3fi2e9fhd"
@@ -240,7 +240,7 @@ def test_hash_matches_strict():
         hash_matches(fname, bad_hash, strict=True, source="Neverland")
     assert "Neverland" in str(error.value)
     for alg in ("sha512", "md5"):
-        bad_hash = "{}:p98oh2dl2j2h2p8e9yfho3fi2e9fhd".format(alg)
+        bad_hash = f"{alg}:p98oh2dl2j2h2p8e9yfho3fi2e9fhd"
         with pytest.raises(ValueError) as error:
             hash_matches(fname, bad_hash, strict=True)
         assert fname in str(error.value)
@@ -262,7 +262,7 @@ def test_temporary_file():
         assert Path(tmp).exists()
         with open(tmp, "w") as outfile:
             outfile.write("Meh")
-        with open(tmp, "r") as infile:
+        with open(tmp) as infile:
             assert infile.read().strip() == "Meh"
     assert not Path(tmp).exists()
 
@@ -275,7 +275,7 @@ def test_temporary_file_path():
             assert path in tmp
             with open(tmp, "w") as outfile:
                 outfile.write("Meh")
-            with open(tmp, "r") as infile:
+            with open(tmp) as infile:
                 assert infile.read().strip() == "Meh"
         assert not Path(tmp).exists()
 

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -45,7 +45,9 @@ def test_unique_name_long():
 
 
 @pytest.mark.parametrize(
-    "pool", [ThreadPoolExecutor, ProcessPoolExecutor], ids=["threads", "processes"],
+    "pool",
+    [ThreadPoolExecutor, ProcessPoolExecutor],
+    ids=["threads", "processes"],
 )
 def test_make_local_storage_parallel(pool, monkeypatch):
     "Try to create the cache folder in parallel"
@@ -98,7 +100,8 @@ def test_local_storage_makedirs_permissionerror(monkeypatch):
 
     with pytest.raises(PermissionError) as error:
         make_local_storage(
-            path=data_cache, env="SOME_VARIABLE",
+            path=data_cache,
+            env="SOME_VARIABLE",
         )
         assert "Pooch could not create data cache" in str(error)
         assert "'SOME_VARIABLE'" in str(error)
@@ -121,7 +124,8 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
 
         with pytest.raises(PermissionError) as error:
             make_local_storage(
-                path=data_cache, env="SOME_VARIABLE",
+                path=data_cache,
+                env="SOME_VARIABLE",
             )
             assert "Pooch could not write to data cache" in str(error)
             assert "'SOME_VARIABLE'" in str(error)

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -123,7 +123,7 @@ def data_over_ftp(server, fname):
     server_path = os.path.join(server.anon_root, fname)
     try:
         shutil.copyfile(package_path, server_path)
-        url = "ftp://localhost/{}".format(fname)
+        url = f"ftp://localhost/{fname}"
         yield url
     finally:
         if os.path.exists(server_path):

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -286,9 +286,7 @@ def make_local_storage(path, env=None):
         ]
         if env is not None:
             message.append(
-                "Use environment variable '{}' to specify a different location.".format(
-                    env
-                )
+                f"Use environment variable '{env}' to specify a different location."
             )
         raise PermissionError(" ".join(message)) from error
 
@@ -373,12 +371,10 @@ def hash_matches(fname, known_hash, strict=False, source=None):
         if source is None:
             source = str(fname)
         raise ValueError(
-            "{} hash of downloaded file ({}) does not match the known hash:"
-            " expected {} but got {}. Deleted download for safety."
-            " The downloaded file may have been corrupted or"
-            " the known hash may be outdated.".format(
-                algorithm.upper(), source, known_hash, new_hash,
-            )
+            f"{algorithm.upper()} hash of downloaded file ({source}) does not match"
+            f" the known hash: expected {known_hash} but got {new_hash}. Deleted"
+            " download for safety. The downloaded file may have been corrupted or"
+            " the known hash may be outdated."
         )
     return matches
 

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -93,7 +93,7 @@ def file_hash(fname, alg="sha256"):
 
     """
     if alg not in hashlib.algorithms_available:
-        raise ValueError("Algorithm '{}' not available in hashlib".format(alg))
+        raise ValueError(f"Algorithm '{alg}' not available in hashlib")
     # Calculate the hash in chunks to avoid overloading the memory
     chunksize = 65536
     hasher = hashlib.new(alg)
@@ -281,7 +281,7 @@ def make_local_storage(path, env=None):
     except PermissionError as error:
         message = [
             str(error),
-            "| Pooch could not {} data cache folder '{}'.".format(action, path),
+            f"| Pooch could not {action} data cache folder '{path}'.",
             "Will not be able to download data files.",
         ]
         if env is not None:
@@ -453,5 +453,5 @@ def unique_file_name(url):
     # Crop the start of the file name to fit 255 characters including the hash
     # and the :
     fname = fname[-(255 - len(md5) - 1) :]
-    unique_name = "{}-{}".format(md5, fname)
+    unique_name = f"{md5}-{fname}"
     return unique_name

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ CLASSIFIERS = [
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -54,7 +53,7 @@ PACKAGE_DATA = {
     ]
 }
 INSTALL_REQUIRES = ["requests", "packaging", "appdirs"]
-PYTHON_REQUIRES = ">=3.5"
+PYTHON_REQUIRES = ">=3.6"
 
 if __name__ == "__main__":
     setup(

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3 :: Only",
-    "License :: OSI Approved :: {}".format(LICENSE),
+    f"License :: OSI Approved :: {LICENSE}",
 ]
 PLATFORMS = "Any"
 PACKAGES = find_packages(exclude=["doc"])


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->
Fixes #199.

* Drop support for Python 3.5
* Upgrade Python syntax with https://github.com/asottile/pyupgrade with `--py36-plus`
* Update some more `.format` to f-strings

**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [n/a] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [n/a] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [n/a] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
