### PR TITLE
Update black formatting and require >=20.8b1

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install requirements
-        run: pip install black
+        run: pip install black>=20.8b1
 
       - name: List installed packages
         run: pip freeze

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - pytest-cov
     - pytest-localftpserver
     - coverage
-    - black
+    - black>=20.8b1
     - flake8
     - pylint=2.4.*
     - sphinx=2.2.1

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -207,7 +207,10 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
 
     if action in ("download", "update"):
         get_logger().info(
-            "%s data from '%s' to file '%s'.", verb, url, str(full_path),
+            "%s data from '%s' to file '%s'.",
+            verb,
+            url,
+            str(full_path),
         )
 
         if downloader is None:
@@ -495,7 +498,11 @@ class Pooch:
 
         if action in ("download", "update"):
             get_logger().info(
-                "%s file '%s' from '%s' to '%s'.", verb, fname, url, str(self.abspath),
+                "%s file '%s' from '%s' to '%s'.",
+                verb,
+                fname,
+                url,
+                str(self.abspath),
             )
 
             if downloader is None:

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -281,8 +281,10 @@ class Decompress:  # pylint: disable=too-few-public-methods
         if self.method == "auto":
             ext = os.path.splitext(fname)[-1]
             if ext not in self.extensions:
-                message = "Unrecognized file extension '{}'. Must be one of '{}'.".format(
-                    ext, list(self.extensions.keys())
+                message = (
+                    "Unrecognized file extension '{}'. Must be one of '{}'.".format(
+                        ext, list(self.extensions.keys())
+                    )
                 )
                 if ext in {".zip", ".tar"}:
                     message = " ".join([message, error_archives])

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -45,7 +45,9 @@ def test_unique_name_long():
 
 
 @pytest.mark.parametrize(
-    "pool", [ThreadPoolExecutor, ProcessPoolExecutor], ids=["threads", "processes"],
+    "pool",
+    [ThreadPoolExecutor, ProcessPoolExecutor],
+    ids=["threads", "processes"],
 )
 def test_make_local_storage_parallel(pool, monkeypatch):
     "Try to create the cache folder in parallel"
@@ -98,7 +100,8 @@ def test_local_storage_makedirs_permissionerror(monkeypatch):
 
     with pytest.raises(PermissionError) as error:
         make_local_storage(
-            path=data_cache, env="SOME_VARIABLE",
+            path=data_cache,
+            env="SOME_VARIABLE",
         )
         assert "Pooch could not create data cache" in str(error)
         assert "'SOME_VARIABLE'" in str(error)
@@ -121,7 +124,8 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
 
         with pytest.raises(PermissionError) as error:
             make_local_storage(
-                path=data_cache, env="SOME_VARIABLE",
+                path=data_cache,
+                env="SOME_VARIABLE",
             )
             assert "Pooch could not write to data cache" in str(error)
             assert "'SOME_VARIABLE'" in str(error)

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -377,7 +377,10 @@ def hash_matches(fname, known_hash, strict=False, source=None):
             " expected {} but got {}. Deleted download for safety."
             " The downloaded file may have been corrupted or"
             " the known hash may be outdated.".format(
-                algorithm.upper(), source, known_hash, new_hash,
+                algorithm.upper(),
+                source,
+                known_hash,
+                new_hash,
             )
         )
     return matches


### PR DESCRIPTION
After version 19, black changed the formatting slightly in a few files.
This updates the format and sets a minimum version of black in the
development environment and the CI.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
