### PR TITLE
Use pip instead of conda to speed up Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,10 +52,10 @@ jobs:
             python: 3.8
             dependencies: optional
     env:
-      CONDA_REQUIREMENTS: requirements.txt
-      CONDA_REQUIREMENTS_DEV: requirements-dev.txt
-      CONDA_REQUIREMENTS_OPTIONAL: requirements-optional.txt
-      CONDA_INSTALL_EXTRA:
+      REQUIREMENTS: requirements.txt
+      REQUIREMENTS_DEV: requirements-dev.txt
+      REQUIREMENTS_OPTIONAL: requirements-optional.txt
+      INSTALL_EXTRA:
       DEPENDENCIES: ${{ matrix.dependencies }}
       # Used to tag codecov submissions
       OS: ${{ matrix.os }}
@@ -80,56 +80,43 @@ jobs:
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
-      - name: Setup caching for conda packages
-        uses: actions/cache@v2
-        with:
-          path: ~/conda_pkgs_dir
-          key: conda-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('requirements*.txt') }}
-
-      - name: Setup miniconda
-        uses: goanpeca/setup-miniconda@v1
+      - name: Setup Python
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-          miniconda-version: "latest"
-          auto-update-conda: true
-          channels: conda-forge
-          show-channel-urls: true
-          activate-environment: testing
-          # Needed for caching
-          use-only-tar-bz2: true
 
       - name: Install requirements
         run: |
-          requirements_file=full-conda-requirements.txt
-          if [ ! -z "$CONDA_REQUIREMENTS" ]; then
-              echo "Capturing dependencies from $CONDA_REQUIREMENTS"
-              cat $CONDA_REQUIREMENTS >> $requirements_file
+          requirements_file=requirements-full.txt
+          if [ ! -z "$REQUIREMENTS" ]; then
+              echo "Capturing dependencies from $REQUIREMENTS"
+              cat $REQUIREMENTS >> $requirements_file
           fi
-          if [ ! -z "$CONDA_REQUIREMENTS_DEV" ]; then
-              echo "Capturing dependencies from $CONDA_REQUIREMENTS_DEV"
-              cat $CONDA_REQUIREMENTS_DEV >> $requirements_file
+          if [ ! -z "$REQUIREMENTS_DEV" ]; then
+              echo "Capturing dependencies from $REQUIREMENTS_DEV"
+              cat $REQUIREMENTS_DEV >> $requirements_file
           fi
           if [ "$DEPENDENCIES" == "optional" ]; then
-              echo "Capturing optional dependencies from $CONDA_REQUIREMENTS_OPTIONAL"
-              cat $CONDA_REQUIREMENTS_OPTIONAL >> $requirements_file
+              echo "Capturing optional dependencies from $REQUIREMENTS_OPTIONAL"
+              cat $REQUIREMENTS_OPTIONAL >> $requirements_file
           fi
-          if [ ! -z "$CONDA_INSTALL_EXTRA" ]; then
-              echo "Capturing extra dependencies: $CONDA_INSTALL_EXTRA"
+          if [ ! -z "$INSTALL_EXTRA" ]; then
+              echo "Capturing extra dependencies: $INSTALL_EXTRA"
               echo "# Extra" >> $requirements_file
               # Use xargs to print one argument per line
-              echo $CONDA_INSTALL_EXTRA | xargs -n 1 >> $requirements_file
+              echo $INSTALL_EXTRA | xargs -n 1 >> $requirements_file
           fi
           if [ -f $requirements_file ]; then
               echo "Collected dependencies:"
               cat $requirements_file
               echo ""
-              conda install --quiet --file $requirements_file python=$PYTHON
+              python -m pip install --requirement $requirements_file
           else
               echo "No requirements defined."
           fi
 
       - name: List installed packages
-        run: conda list
+        run: pip freeze
 
       - name: Build source and wheel distributions
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
       REQUIREMENTS: requirements.txt
       REQUIREMENTS_DEV: requirements-dev.txt
       REQUIREMENTS_OPTIONAL: requirements-optional.txt
-      INSTALL_EXTRA: setuptools wheel
+      INSTALL_EXTRA:
       DEPENDENCIES: ${{ matrix.dependencies }}
       # Used to tag codecov submissions
       OS: ${{ matrix.os }}
@@ -112,6 +112,9 @@ jobs:
               echo "Collected dependencies:"
               cat $requirements_file
               echo ""
+              # Install wheel before anything else so pip can use wheels for
+              # other packages.
+              python -m pip install setuptools wheel
               python -m pip install --requirement $requirements_file
           else
               echo "No requirements defined."

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,6 +87,19 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Get the pip cache folder
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Setup caching for pip packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install requirements
         run: |
           requirements_file=requirements-full.txt

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,8 +21,10 @@ on:
 # Use bash by default in all jobs
 defaults:
   run:
-    # The -l {0} is necessary for conda environments to be activated
-    shell: bash -l {0}
+    # Using "-l {0}" is necessary for conda environments to be activated
+    # But this breaks on MacOS if using actions/setup-python:
+    # https://github.com/actions/setup-python/issues/132
+    shell: bash
 
 jobs:
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,7 +55,7 @@ jobs:
       REQUIREMENTS: requirements.txt
       REQUIREMENTS_DEV: requirements-dev.txt
       REQUIREMENTS_OPTIONAL: requirements-optional.txt
-      INSTALL_EXTRA:
+      INSTALL_EXTRA: setuptools wheel
       DEPENDENCIES: ${{ matrix.dependencies }}
       # Used to tag codecov submissions
       OS: ${{ matrix.os }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,7 @@ jobs:
       REQUIREMENTS: requirements.txt
       REQUIREMENTS_DEV: requirements-dev.txt
       REQUIREMENTS_OPTIONAL: requirements-optional.txt
-      INSTALL_EXTRA: setuptools wheel
+      INSTALL_EXTRA:
       DEPENDENCIES:
 
     steps:
@@ -161,6 +161,9 @@ jobs:
               echo "Collected dependencies:"
               cat $requirements_file
               echo ""
+              # Install wheel before anything else so pip can use wheels for
+              # other packages.
+              python -m pip install setuptools wheel
               python -m pip install --requirement $requirements_file
           else
               echo "No requirements defined."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,6 +136,19 @@ jobs:
         with:
           python-version: 3.8
 
+      - name: Get the pip cache folder
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Setup caching for pip packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install requirements
         run: |
           requirements_file=requirements-full.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,7 +107,7 @@ jobs:
       REQUIREMENTS: requirements.txt
       REQUIREMENTS_DEV: requirements-dev.txt
       REQUIREMENTS_OPTIONAL: requirements-optional.txt
-      INSTALL_EXTRA:
+      INSTALL_EXTRA: setuptools wheel
       DEPENDENCIES:
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,12 +104,11 @@ jobs:
     # Only publish from the origin repository, not forks
     if: github.repository == 'fatiando/pooch'
     env:
-      CONDA_REQUIREMENTS: requirements.txt
-      CONDA_REQUIREMENTS_DEV: requirements-dev.txt
-      CONDA_REQUIREMENTS_OPTIONAL: requirements-optional.txt
-      CONDA_INSTALL_EXTRA:
+      REQUIREMENTS: requirements.txt
+      REQUIREMENTS_DEV: requirements-dev.txt
+      REQUIREMENTS_OPTIONAL: requirements-optional.txt
+      INSTALL_EXTRA:
       DEPENDENCIES:
-      PYTHON: 3.8
 
     steps:
 
@@ -130,56 +129,43 @@ jobs:
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
-      - name: Setup caching for conda packages
-        uses: actions/cache@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
         with:
-          path: ~/conda_pkgs_dir
-          key: conda-${{ runner.os }}-${{ env.PYTHON }}-${{ hashFiles('requirements*.txt') }}
-
-      - name: Setup miniconda
-        uses: goanpeca/setup-miniconda@v1
-        with:
-          python-version: ${{ env.PYTHON }}
-          miniconda-version: "latest"
-          auto-update-conda: true
-          channels: conda-forge
-          show-channel-urls: true
-          activate-environment: testing
-          # Needed for caching
-          use-only-tar-bz2: true
+          python-version: 3.8
 
       - name: Install requirements
         run: |
-          requirements_file=full-conda-requirements.txt
-          if [ ! -z "$CONDA_REQUIREMENTS" ]; then
-              echo "Capturing dependencies from $CONDA_REQUIREMENTS"
-              cat $CONDA_REQUIREMENTS >> $requirements_file
+          requirements_file=requirements-full.txt
+          if [ ! -z "$REQUIREMENTS" ]; then
+              echo "Capturing dependencies from $REQUIREMENTS"
+              cat $REQUIREMENTS >> $requirements_file
           fi
-          if [ ! -z "$CONDA_REQUIREMENTS_DEV" ]; then
-              echo "Capturing dependencies from $CONDA_REQUIREMENTS_DEV"
-              cat $CONDA_REQUIREMENTS_DEV >> $requirements_file
+          if [ ! -z "$REQUIREMENTS_DEV" ]; then
+              echo "Capturing dependencies from $REQUIREMENTS_DEV"
+              cat $REQUIREMENTS_DEV >> $requirements_file
           fi
           if [ "$DEPENDENCIES" == "optional" ]; then
-              echo "Capturing optional dependencies from $CONDA_REQUIREMENTS_OPTIONAL"
-              cat $CONDA_REQUIREMENTS_OPTIONAL >> $requirements_file
+              echo "Capturing optional dependencies from $REQUIREMENTS_OPTIONAL"
+              cat $REQUIREMENTS_OPTIONAL >> $requirements_file
           fi
-          if [ ! -z "$CONDA_INSTALL_EXTRA" ]; then
-              echo "Capturing extra dependencies: $CONDA_INSTALL_EXTRA"
+          if [ ! -z "$INSTALL_EXTRA" ]; then
+              echo "Capturing extra dependencies: $INSTALL_EXTRA"
               echo "# Extra" >> $requirements_file
               # Use xargs to print one argument per line
-              echo $CONDA_INSTALL_EXTRA | xargs -n 1 >> $requirements_file
+              echo $INSTALL_EXTRA | xargs -n 1 >> $requirements_file
           fi
           if [ -f $requirements_file ]; then
               echo "Collected dependencies:"
               cat $requirements_file
               echo ""
-              conda install --quiet --file $requirements_file python=$PYTHON
+              python -m pip install --requirement $requirements_file
           else
               echo "No requirements defined."
           fi
 
       - name: List installed packages
-        run: conda list
+        run: pip freeze
 
       - name: Build source and wheel distributions
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,8 +19,10 @@ on:
 # Use bash by default in all jobs
 defaults:
   run:
-    # The -l {0} is necessary for conda environments to be activated
-    shell: bash -l {0}
+    # Using "-l {0}" is necessary for conda environments to be activated
+    # But this breaks on MacOS if using actions/setup-python:
+    # https://github.com/actions/setup-python/issues/132
+    shell: bash
 
 jobs:
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: '3.8'
 
       - name: Install requirements
-        run: pip install black>=20.8b1
+        run: pip install black
 
       - name: List installed packages
         run: pip freeze

--- a/environment.yml
+++ b/environment.yml
@@ -16,5 +16,5 @@ dependencies:
     - black>=20.8b1
     - flake8
     - pylint=2.4.*
-    - sphinx
-    - sphinx_rtd_theme
+    - sphinx==3.3.*
+    - sphinx_rtd_theme==0.5.0

--- a/environment.yml
+++ b/environment.yml
@@ -16,5 +16,5 @@ dependencies:
     - black>=20.8b1
     - flake8
     - pylint=2.4.*
-    - sphinx=2.2.1
-    - sphinx_rtd_theme=0.4.3
+    - sphinx
+    - sphinx_rtd_theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ pytest
 pytest-cov
 pytest-localftpserver
 coverage
-sphinx==2.2.1
-sphinx_rtd_theme==0.4.3
+sphinx
+sphinx_rtd_theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ pytest
 pytest-cov
 pytest-localftpserver
 coverage
-sphinx
-sphinx_rtd_theme
+sphinx==3.3.*
+sphinx_rtd_theme==0.5.0


### PR DESCRIPTION
Switch to using the built-in Python and pip to setup Actions workflows
instead of conda/miniconda. This speeds up the workflows by a large
amount and is worth the trade-off since we don't have any dependencies
that require conda.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
