### PR TITLE
Add seaborn-image to list of packages using Pooch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,7 @@ For **package developers** including sample data in their projects:
 Projects using Pooch
 --------------------
 
+* `seaborn-image <https://github.com/SarthakJariwala/seaborn-image>`__
 * `scikit-image <https://github.com/scikit-image/scikit-image>`__
 * `MetPy <https://github.com/Unidata/MetPy>`__
 * `Verde <https://github.com/fatiando/verde>`__


### PR DESCRIPTION
Added [seaborn-image](https://github.com/SarthakJariwala/seaborn-image) to README as one of the libraries using `pooch`. 

`seaborn-image` [recently](https://github.com/SarthakJariwala/seaborn-image/pull/74) started using `pooch` for all sample dataset management.

Thanks for this amazing and easy to use library!