### PR TITLE
FIX, ENH: Handle nested archive members; allow arbitrary unpack locations

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,8 +8,9 @@ order by last name) and are considered "The Pooch Developers":
 * [Mathias Hauser](https://github.com/mathause) - Institute for Atmospheric and Climate Science, ETH Zurich, Zurich, Switzerland (ORCID: [0000-0002-0057-4878](https://orcid.org/0000-0002-0057-4878))
 * [Danilo Horta](https://github.com/horta) - EMBL-EBI, UK
 * [Hugo van Kemenade](https://github.com/hugovk) - Independent (Non-affiliated) (ORCID: [0000-0001-5715-8632](https://www.orcid.org/0000-0001-5715-8632))
-* [Kacper Kowalik](https://github.com/Xarthisius) - National Center for Supercomputing Applications, Univeristy of Illinois at Urbana-Champaign, USA (ORCID: [0000-0003-1709-3744](https://www.orcid.org/0000-0003-1709-3744))
+* [Kacper Kowalik](https://github.com/Xarthisius) - National Center for Supercomputing Applications, University of Illinois at Urbana-Champaign, USA (ORCID: [0000-0003-1709-3744](https://www.orcid.org/0000-0003-1709-3744))
 * [John Leeman](https://github.com/jrleeman)
+* [Daniel McCloy](https://github.com/drammock) - University of Washington, USA (ORCID: [0000-0002-7572-3241](https://orcid.org/0000-0002-7572-3241))
 * [Rémi Rampin](https://github.com/remram44) - New York University, USA (ORCID: [0000-0002-0524-2282](https://www.orcid.org/0000-0002-0524-2282))
 * [Daniel Shapero](https://github.com/danshapero) - Polar Science Center, University of Washington Applied Physics Lab, USA (ORCID: [0000-0002-3651-0649](https://www.orcid.org/0000-0002-3651-0649))
 * [Santiago Soler](https://github.com/santisoler) - CONICET, Argentina; Instituto Geofísico Sismológico Volponi, Universidad Nacional de San Juan, Argentina (ORCID: [0000-0001-9202-5317](https://www.orcid.org/0000-0001-9202-5317))

--- a/doc/processors.rst
+++ b/doc/processors.rst
@@ -67,7 +67,7 @@ For example, to extract a single file from a zip archive:
         Load a large zipped sample data as a pandas.DataFrame.
         """
         # Extract the file "actual-data-file.txt" from the archive
-        unpack =  Unzip(members=["actual-data-file.txt"])
+        unpack = Unzip(members=["actual-data-file.txt"])
         # Pass in the processor to unzip the data file
         fnames = GOODBOY.fetch("zipped-data-file.zip", processor=unpack)
         # Returns the paths of all extract members (in our case, only one)
@@ -77,7 +77,34 @@ For example, to extract a single file from a zip archive:
         data = pandas.read_csv(fname)
         return data
 
-Or to extract all files into a folder and return the path to each file:
+By default, the :class:`~pooch.Unzip` processor (and similarly the
+:class:`~pooch.Untar` processor) will create a new folder in the same location
+as the downloaded archive file, and give it the same name as the archive file
+with the suffix ``.unzip`` (or ``.untar``) appended. If you want to change the
+location of the unpacked files, you can provide a parameter ``extract_dir`` to
+the processor to tell it where you want to unpack the files:
+
+.. code:: python
+
+    from pooch import Untar
+
+
+    def fetch_and_unpack_tar_file():
+        """
+        Unpack a file from a tar archive to a custom subdirectory in the cache.
+        """
+        # Extract a single file from the archive, to a specific location
+        unpack_to_custom_dir = Untar(members=["actual-data-file.txt"],
+                                     extract_dir="custom_folder")
+        # Pass in the processor to untar the data file
+        fnames = GOODBOY.fetch("tarred-data-file.tar.gz", processor=unpack)
+        # Returns the paths of all extract members (in our case, only one)
+        fname = fnames[0]
+        return fname
+
+
+To extract all files into a folder and return the path to each file, simply
+omit the ``members`` parameter:
 
 .. code:: python
 
@@ -85,10 +112,8 @@ Or to extract all files into a folder and return the path to each file:
         """
         Load all files from a zipped archive.
         """
-        # Pass in the processor to unzip the data file
         fnames = GOODBOY.fetch("zipped-archive.zip", processor=Unzip())
-        data = [pandas.read_csv(fname) for fname in fnames]
-        return data
+        return fnames
 
 Use :class:`pooch.Untar` to do the exact same for tar archives (with optional
 compression).

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -116,6 +116,13 @@ class Unzip(ExtractorProcessor):  # pylint: disable=too-few-public-methods
         If None, will unpack all files in the zip archive. Otherwise, *members*
         must be a list of file names to unpack from the archive. Only these
         files will be unpacked.
+    extract_dir : str or None
+        If None, files will be unpacked to the default location (a folder in
+        the same location as the downloaded zip file, with the suffix
+        ``.unzip`` added). Otherwise, files will be unpacked to
+        ``extract_dir``, which is interpreted as a *relative path* (relative to
+        the cache location provided by :func:`pooch.retrieve` or
+        :meth:`pooch.Pooch.fetch`).
 
     """
 
@@ -168,6 +175,13 @@ class Untar(ExtractorProcessor):  # pylint: disable=too-few-public-methods
         If None, will unpack all files in the archive. Otherwise, *members*
         must be a list of file names to unpack from the archive. Only these
         files will be unpacked.
+    extract_dir : str or None
+        If None, files will be unpacked to the default location (a folder in
+        the same location as the downloaded tar file, with the suffix
+        ``.untar`` added). Otherwise, files will be unpacked to
+        ``extract_dir``, which is interpreted as a *relative path* (relative to
+        the cache location  provided by :func:`pooch.retrieve` or
+        :meth:`pooch.Pooch.fetch`).
     """
 
     suffix = ".untar"

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -80,8 +80,7 @@ class ExtractorProcessor:  # pylint: disable=too-few-public-methods
             get_logger().warn("Ignoring 'suffix' because 'extract_dir' was provided.")
         if action in ("update", "download") or not os.path.exists(self.extract_dir):
             # Make sure that the folder with the extracted files exists
-            if not os.path.exists(self.extract_dir):
-                os.makedirs(self.extract_dir)
+            os.makedirs(self.extract_dir, exist_ok=True)
             self._extract_file(fname, self.extract_dir)
         # Get a list of all file names (including subdirectories) in our folder
         # of unzipped files.
@@ -139,6 +138,11 @@ class Unzip(ExtractorProcessor):  # pylint: disable=too-few-public-methods
                     get_logger().info(
                         "Extracting '%s' from '%s' to '%s'", member, fname, extract_dir
                     )
+                    # make sure the target folder exists for nested members
+                    if len(member.split(os.path.sep)) > 1:
+                        member_dir, _ = member.rsplit(os.path.sep, maxsplit=1)
+                        full_dir_path = os.path.join(extract_dir, member_dir)
+                        os.makedirs(full_dir_path, exist_ok=True)
                     # Extract the data file from within the archive
                     with zip_file.open(member) as data_file:
                         # Save it to our desired file name
@@ -185,6 +189,11 @@ class Untar(ExtractorProcessor):  # pylint: disable=too-few-public-methods
                     get_logger().info(
                         "Extracting '%s' from '%s' to '%s'", member, fname, extract_dir
                     )
+                    # make sure the target folder exists for nested members
+                    if len(member.split(os.path.sep)) > 1:
+                        member_dir, _ = member.rsplit(os.path.sep, maxsplit=1)
+                        full_dir_path = os.path.join(extract_dir, member_dir)
+                        os.makedirs(full_dir_path, exist_ok=True)
                     # Extract the data file from within the archive
                     # Python 2.7: extractfile doesn't return a context manager
                     data_file = tar_file.extractfile(member)

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -76,8 +76,9 @@ class ExtractorProcessor:  # pylint: disable=too-few-public-methods
             )
         if self.extract_dir is None:
             self.extract_dir = fname + self.suffix
-        elif self.suffix is not None:
-            get_logger().warn("Ignoring 'suffix' because 'extract_dir' was provided.")
+        else:
+            archive_dir = fname.rsplit(os.path.sep, maxsplit=1)[0]
+            self.extract_dir = os.path.join(archive_dir, self.extract_dir)
         if action in ("update", "download") or not os.path.exists(self.extract_dir):
             # Make sure that the folder with the extracted files exists
             os.makedirs(self.extract_dir, exist_ok=True)

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -13,6 +13,7 @@ import bz2
 import gzip
 import lzma
 import shutil
+from pathlib import Path
 from zipfile import ZipFile
 from tarfile import TarFile
 
@@ -147,9 +148,9 @@ class Unzip(ExtractorProcessor):  # pylint: disable=too-few-public-methods
                         "Extracting '%s' from '%s' to '%s'", member, fname, extract_dir
                     )
                     # make sure the target folder exists for nested members
-                    if len(member.split(os.path.sep)) > 1:
-                        member_dir, _ = member.rsplit(os.path.sep, maxsplit=1)
-                        full_dir_path = os.path.join(extract_dir, member_dir)
+                    parts = Path(member).parts
+                    if len(parts) > 1:
+                        full_dir_path = os.path.join(extract_dir, *parts[:-1])
                         os.makedirs(full_dir_path, exist_ok=True)
                     # Extract the data file from within the archive
                     with zip_file.open(member) as data_file:
@@ -205,9 +206,9 @@ class Untar(ExtractorProcessor):  # pylint: disable=too-few-public-methods
                         "Extracting '%s' from '%s' to '%s'", member, fname, extract_dir
                     )
                     # make sure the target folder exists for nested members
-                    if len(member.split(os.path.sep)) > 1:
-                        member_dir, _ = member.rsplit(os.path.sep, maxsplit=1)
-                        full_dir_path = os.path.join(extract_dir, member_dir)
+                    parts = Path(member).parts
+                    if len(parts) > 1:
+                        full_dir_path = os.path.join(extract_dir, *parts[:-1])
                         os.makedirs(full_dir_path, exist_ok=True)
                     # Extract the data file from within the archive
                     # Python 2.7: extractfile doesn't return a context manager


### PR DESCRIPTION
closes #223 

This PR does two things:

1. handle cases where the `members` passed to a processor reside within subfolders inside the archive, by creating the necessary destination subfolders before attempting to write the unpacked file. Previously, using a processor like this `Untar(members=['archive_internal_subfolder/desired_file.txt'])` would fail with a `FileNotFoundError`.
2. allow processors to unpack to arbitrary locations, instead of being restricted to a folder with the same name as the archive with a suffix appended.  This is done with a new optional parameter to the processors called `extract_dir`.  If `extract_dir` is `None` (the default) then the current suffix-based approach is used as a fallback.

**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] ~~Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.~~ N/A
- [x] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
