### PR TITLE
Don't register a non-Null logging handler

### DIFF
--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -20,7 +20,7 @@ from packaging.version import Version
 
 
 LOGGER = logging.Logger("pooch")
-LOGGER.addHandler(logging.StreamHandler())
+LOGGER.addHandler(logging.NullHandler())
 
 
 def get_logger():


### PR DESCRIPTION
Per the Python docs [1]: "It is strongly advised that you do not add any handlers other than NullHandler to your library’s loggers."

[1] https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library

Pooch is a library, so the best practice to only add "NullHandler" and to let _applications_ add their own handlers if desired.

I imagine this change might have some implications for Pooch users, but I think it probably makes sense? On the other hand, I know the boundaries between "applications" and "libraries" can get blurry for libraries that are mostly run interactively...