### PR TITLE
Add support for figshare and Zenodo DOIs as URLs

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -20,6 +20,7 @@ Use cases
     * Make sure everyone running the code has the same version of the data
       files by verifying cryptographic hashes.
     * Multiple download protocols HTTP/FTP/SFT and basic authentication.
+    * Download from a `figshare <https://www.figshare.com>`__ DOI directly.
     * Built-in utilities to unzip/decompress files upon download
 
     **Start here:** :ref:`retrieve`

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -20,7 +20,8 @@ Use cases
     * Make sure everyone running the code has the same version of the data
       files by verifying cryptographic hashes.
     * Multiple download protocols HTTP/FTP/SFT and basic authentication.
-    * Download from a `figshare <https://www.figshare.com>`__ DOI directly.
+    * Download from Digital Object Identifiers (DOIs) issued by repositories
+      like figshare and Zenodo.
     * Built-in utilities to unzip/decompress files upon download
 
     **Start here:** :ref:`retrieve`

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -38,7 +38,7 @@ Downloaders
    HTTPDownloader
    FTPDownloader
    SFTPDownloader
-   FigshareDownloader
+   DOIDownloader
 
 Processors
 ----------

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -38,6 +38,7 @@ Downloaders
    HTTPDownloader
    FTPDownloader
    SFTPDownloader
+   FigshareDownloader
 
 Processors
 ----------

--- a/doc/downloaders.rst
+++ b/doc/downloaders.rst
@@ -4,8 +4,8 @@ Downloaders: Customizing the download
 =====================================
 
 By default, :meth:`pooch.Pooch.fetch` and :meth:`pooch.retrieve` will detect
-the download protocol from the given URL (HTTP, FTP, or SFTP) and use the
-appropriate download method.
+the download protocol from the given URL (HTTP, FTP, SFTP, figshare DOI) and
+use the appropriate download method.
 Sometimes this is not enough: some servers require logins, redirections, or
 other non-standard operations.
 To get around this, use the ``downloader`` argument of

--- a/doc/downloaders.rst
+++ b/doc/downloaders.rst
@@ -4,8 +4,8 @@ Downloaders: Customizing the download
 =====================================
 
 By default, :meth:`pooch.Pooch.fetch` and :meth:`pooch.retrieve` will detect
-the download protocol from the given URL (HTTP, FTP, SFTP, figshare DOI) and
-use the appropriate download method.
+the download protocol from the given URL (HTTP, FTP, SFTP, DOI) and use the
+appropriate download method.
 Sometimes this is not enough: some servers require logins, redirections, or
 other non-standard operations.
 To get around this, use the ``downloader`` argument of

--- a/doc/protocols.rst
+++ b/doc/protocols.rst
@@ -4,9 +4,9 @@ Download protocols
 ==================
 
 Pooch supports the HTTP, FTP, and SFTP protocols by default.
-It also includes a custom protocol for `figshare
-<https://www.figshare.com>`__
-Digital Object Identifiers (DOI; see :ref:`below <doidownloads>`).
+It also includes a custom protocol for Digital Object Identifiers (DOI) providers
+like `figshare <https://www.figshare.com>`__ and
+`Zenodo <https://www.zenodo.org>`__ (see :ref:`below <doidownloads>`).
 It will **automatically detect** the correct protocol from the URL and use the
 appropriate download method.
 
@@ -46,12 +46,13 @@ You can even specify custom functions for the download or login credentials for
 
 .. _doidownloads:
 
-figshare
---------
+Digital Object Identifiers (DOIs)
+---------------------------------
 
-Pooch can download files stored in figshare from the DOI by formatting the URL
-as ``figshare://{DOI}/{file name}``.
-
+Pooch can download files stored in data repositories from the DOI by formatting
+the URL as ``{repository}://{DOI}/{file name}``.
+See :class:`pooch.DOIDownloader` for more details and a list of supported
+repositories.
 
 For example, one of our test files (``"tiny-data.txt"``) is stored in the
 figshare dataset
@@ -88,5 +89,3 @@ figshare dataset:
         fname = POOCH.fetch("tiny-data.txt")
         data = numpy.loadtxt(fname)
         return data
-
-See :class:`pooch.DOIDownloader` for more details.

--- a/doc/protocols.rst
+++ b/doc/protocols.rst
@@ -89,4 +89,4 @@ figshare dataset:
         data = numpy.loadtxt(fname)
         return data
 
-See :class:`pooch.FigshareDownloader` for more details.
+See :class:`pooch.DOIDownloader` for more details.

--- a/doc/protocols.rst
+++ b/doc/protocols.rst
@@ -4,9 +4,9 @@ Download protocols
 ==================
 
 Pooch supports the HTTP, FTP, and SFTP protocols by default.
-It also includes a custom protocol for Digital Object Identifiers (DOI) providers
-like `figshare <https://www.figshare.com>`__ and
-`Zenodo <https://www.zenodo.org>`__ (see :ref:`below <doidownloads>`).
+It also includes a custom protocol for Digital Object Identifiers (DOI) from
+providers like `figshare <https://www.figshare.com>`__ and `Zenodo
+<https://www.zenodo.org>`__ (see :ref:`below <doidownloads>`).
 It will **automatically detect** the correct protocol from the URL and use the
 appropriate download method.
 
@@ -50,9 +50,14 @@ Digital Object Identifiers (DOIs)
 ---------------------------------
 
 Pooch can download files stored in data repositories from the DOI by formatting
-the URL as ``{repository}://{DOI}/{file name}``.
-See :class:`pooch.DOIDownloader` for more details and a list of supported
-repositories.
+the URL as ``doi:{DOI}/{file name}``.
+Notice that there are no ``//`` like in HTTP/FTP and you must specify a file
+name after the DOI (separated by a ``/``).
+
+.. seealso::
+
+    For a list of supported data repositories, see
+    :class:`pooch.DOIDownloader`.
 
 For example, one of our test files (``"tiny-data.txt"``) is stored in the
 figshare dataset
@@ -62,7 +67,7 @@ We can could use :func:`pooch.retrieve` to download it like so:
 .. code-block:: python
 
     file_path = pooch.retrieve(
-        url="figshare://10.6084/m9.figshare.14763051.v1/tiny-data.txt",
+        url="doi:10.6084/m9.figshare.14763051.v1/tiny-data.txt",
         known_hash="md5:70e2afd3fd7e336ae478b1e740a5f08e",
     )
 
@@ -74,7 +79,7 @@ figshare dataset:
     POOCH = pooch.create(
         path=pooch.os_cache("plumbus"),
         # Use the figshare DOI
-        base_url="figshare://10.6084/m9.figshare.14763051.v1/",
+        base_url="doi:10.6084/m9.figshare.14763051.v1/",
         registry={
             "tiny-data.txt": "md5:70e2afd3fd7e336ae478b1e740a5f08e",
             "store.zip": "md5:7008231125631739b64720d1526619ae",

--- a/doc/protocols.rst
+++ b/doc/protocols.rst
@@ -4,6 +4,9 @@ Download protocols
 ==================
 
 Pooch supports the HTTP, FTP, and SFTP protocols by default.
+It also includes a custom protocol for `figshare
+<https://www.figshare.com>`__
+Digital Object Identifiers (DOI; see :ref:`below <doidownloads>`).
 It will **automatically detect** the correct protocol from the URL and use the
 appropriate download method.
 
@@ -40,3 +43,50 @@ following setup:
 
 You can even specify custom functions for the download or login credentials for
 **authentication**. See :ref:`downloaders` for more information.
+
+.. _doidownloads:
+
+figshare
+--------
+
+Pooch can download files stored in figshare from the DOI by formatting the URL
+as ``figshare://{DOI}/{file name}``.
+
+
+For example, one of our test files (``"tiny-data.txt"``) is stored in the
+figshare dataset
+doi:`10.6084/m9.figshare.14763051.v1 <https://doi.org/10.6084/m9.figshare.14763051.v1>`__.
+We can could use :func:`pooch.retrieve` to download it like so:
+
+.. code-block:: python
+
+    file_path = pooch.retrieve(
+        url="figshare://10.6084/m9.figshare.14763051.v1/tiny-data.txt",
+        known_hash="md5:70e2afd3fd7e336ae478b1e740a5f08e",
+    )
+
+We can also make a :class:`pooch.Pooch` with a registry stored entirely on a
+figshare dataset:
+
+.. code-block:: python
+
+    POOCH = pooch.create(
+        path=pooch.os_cache("plumbus"),
+        # Use the figshare DOI
+        base_url="figshare://10.6084/m9.figshare.14763051.v1/",
+        registry={
+            "tiny-data.txt": "md5:70e2afd3fd7e336ae478b1e740a5f08e",
+            "store.zip": "md5:7008231125631739b64720d1526619ae",
+        },
+    )
+
+
+    def fetch_tiny_data():
+        """
+        Load the tiny data as a numpy array.
+        """
+        fname = POOCH.fetch("tiny-data.txt")
+        data = numpy.loadtxt(fname)
+        return data
+
+See :class:`pooch.FigshareDownloader` for more details.

--- a/doc/retrieve.rst
+++ b/doc/retrieve.rst
@@ -45,14 +45,15 @@ first time they run it.
 
 .. seealso::
 
-    You can use **different hashes** by specifying different algorithm names:
-    ``sha256:XXXXXX``, ``sha1:XXXXXX``, etc. See :ref:`hashes`.
+    Pooch can handle multiple download protocols like HTTP, FTP, SFTP, and
+    even download from repositories like `figshare <https://www.figshare.com>`__
+    and `Zenodo <https://www.zenodo.org>`__ by using the DOI instead of a URL.
+    See :ref:`protocols`.
 
 .. seealso::
 
-    Pooch can handle multiple download protocols like HTTP, FTP, SFTP, and
-    even download from a `figshare <https://www.figshare.com>`__ DOI instead
-    of a URL. See :ref:`protocols`.
+    You can use **different hashes** by specifying different algorithm names:
+    ``sha256:XXXXXX``, ``sha1:XXXXXX``, etc. See :ref:`hashes`.
 
 
 Unknown file hash

--- a/doc/retrieve.rst
+++ b/doc/retrieve.rst
@@ -48,6 +48,12 @@ first time they run it.
     You can use **different hashes** by specifying different algorithm names:
     ``sha256:XXXXXX``, ``sha1:XXXXXX``, etc. See :ref:`hashes`.
 
+.. seealso::
+
+    Pooch can handle multiple download protocols like HTTP, FTP, SFTP, and
+    even download from a `figshare <https://www.figshare.com>`__ DOI instead
+    of a URL. See :ref:`protocols`.
+
 
 Unknown file hash
 -----------------

--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -9,7 +9,12 @@
 # Import functions/classes to make the API
 from .core import Pooch, create, retrieve
 from .utils import os_cache, file_hash, make_registry, check_version, get_logger
-from .downloaders import HTTPDownloader, FTPDownloader, SFTPDownloader
+from .downloaders import (
+    HTTPDownloader,
+    FTPDownloader,
+    SFTPDownloader,
+    FigshareDownloader,
+)
 from .processors import Unzip, Untar, Decompress
 
 # This file is generated automatically by setuptools_scm

--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -13,7 +13,7 @@ from .downloaders import (
     HTTPDownloader,
     FTPDownloader,
     SFTPDownloader,
-    FigshareDownloader,
+    DOIDownloader,
 )
 from .processors import Unzip, Untar, Decompress
 

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -485,7 +485,6 @@ class FigshareDownloader:  # pylint: disable=too-few-public-methods
     data:
 
     >>> import os
-    >>> from pooch import __version__, check_version
     >>> url = "figshare://10.6084/m9.figshare.14763051.v1/tiny-data.txt"
     >>> downloader = FigshareDownloader()
     >>> # Not using with Pooch.fetch so no need to pass an instance of Pooch

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -561,7 +561,9 @@ class DOIDownloader:  # pylint: disable=too-few-public-methods
         if repository not in converters:
             raise ValueError(
                 f"Invalid data repository '{repository}'. Must be one of "
-                f"{list(converters.keys())}."
+                f"{list(converters.keys())}. "
+                "To request or contribute support for this repository, "
+                "please open an issue at https://github.com/fatiando/pooch/issues"
             )
         download_url = converters[repository](
             archive_url=archive_url,

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -535,7 +535,7 @@ class DOIDownloader:  # pylint: disable=too-few-public-methods
         """
         Download the given DOI URL over HTTP to the given output file.
 
-        Uses the repository's API to determined the actual HTTP download URL
+        Uses the repository's API to determine the actual HTTP download URL
         from the given DOI.
 
         Uses :func:`requests.get`.
@@ -599,6 +599,7 @@ def doi_to_url(doi):
     # working at the moment for some reason. Once this gets resolved, this code
     # should be removed.
     if url.split("/")[-1].startswith("zenodo."):
+        print("Meh")
         return f"https://zenodo.org/record/{url.split('/')[-1][7:]}"
 
     if 400 <= response.status_code < 600:

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -599,7 +599,6 @@ def doi_to_url(doi):
     # working at the moment for some reason. Once this gets resolved, this code
     # should be removed.
     if url.split("/")[-1].startswith("zenodo."):
-        print("Meh")
         return f"https://zenodo.org/record/{url.split('/')[-1][7:]}"
 
     if 400 <= response.status_code < 600:

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -594,13 +594,6 @@ def doi_to_url(doi):
     # Use doi.org to resolve the DOI to the repository website.
     response = requests.get(f"https://doi.org/{doi}")
     url = response.url
-
-    # Workaround to get the Zenodo ID. The DOI link for our test data isn't
-    # working at the moment for some reason. Once this gets resolved, this code
-    # should be removed.
-    if url.split("/")[-1].startswith("zenodo."):
-        return f"https://zenodo.org/record/{url.split('/')[-1][7:]}"
-
     if 400 <= response.status_code < 600:
         raise ValueError(
             f"Archive with doi:{doi} not found (see {url}). Is the DOI correct?"

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -464,15 +464,24 @@ class DOIDownloader:  # pylint: disable=too-few-public-methods
     HTTP download link. Uses the :mod:`requests` library to manage downloads
     and interact with the APIs.
 
-    The format of the "URL" is: ``{repository}://{DOI}/{file name}``
+    The **format of the "URL"** is: ``doi:{DOI}/{file name}``.
 
-    Supported repositories:
-
-    * `figshare <https://www.figshare.com>`__: ``figshare``
-    * `Zenodo <https://www.zenodo.org>`__: ``zenodo``
+    Notice that there are no ``//`` like in HTTP/FTP and you must specify a
+    file name after the DOI (separated by a ``/``).
 
     Use with :meth:`pooch.Pooch.fetch` or :func:`pooch.retrieve` to be able to
     download files given the DOI instead of an HTTP link.
+
+    Supported repositories:
+
+    * `figshare <https://www.figshare.com>`__
+    * `Zenodo <https://www.zenodo.org>`__
+
+    .. attention::
+
+        DOIs from other repositories **will not work** since we need to access
+        their particular APIs to find the download links. We welcome
+        suggestions and contributions adding new repositories.
 
     Parameters
     ----------

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -52,6 +52,9 @@ def choose_downloader(url):
     >>> downloader = choose_downloader("ftp://something.com")
     >>> print(downloader.__class__.__name__)
     FTPDownloader
+    >>> downloader = choose_downloader("figshare://DOI/filename.csv")
+    >>> print(downloader.__class__.__name__)
+    FigshareDownloader
 
     """
     known_downloaders = {
@@ -59,6 +62,7 @@ def choose_downloader(url):
         "https": HTTPDownloader,
         "http": HTTPDownloader,
         "sftp": SFTPDownloader,
+        "figshare": FigshareDownloader,
     }
 
     parsed_url = parse_url(url)
@@ -439,3 +443,151 @@ class SFTPDownloader:  # pylint: disable=too-few-public-methods
             connection.close()
             if sftp is not None:
                 sftp.close()
+
+
+class FigshareDownloader:  # pylint: disable=too-few-public-methods
+    """
+    Download manager for fetching files over HTTP/HTTPS.
+
+    When called, downloads the given file URL into the specified local file.
+    Uses the :mod:`requests` library to manage downloads.
+
+    Use with :meth:`pooch.Pooch.fetch` or :func:`pooch.retrieve` to customize
+    the download of files (for example, to use authentication or print a
+    progress bar).
+
+    Parameters
+    ----------
+    progressbar : bool or an arbitrary progress bar object
+        If True, will print a progress bar of the download to standard error
+        (stderr). Requires `tqdm <https://github.com/tqdm/tqdm>`__ to be
+        installed. Alternatively, an arbitrary progress bar object can be
+        passed. See :ref:`custom-progressbar` for details.
+    chunk_size : int
+        Files are streamed *chunk_size* bytes at a time instead of loading
+        everything into memory at one. Usually doesn't need to be changed.
+    **kwargs
+        All keyword arguments given when creating an instance of this class
+        will be passed to :func:`requests.get`.
+
+    Examples
+    --------
+
+    Download one of the data files from the Pooch repository:
+
+    >>> import os
+    >>> from pooch import __version__, check_version
+    >>> url = "https://github.com/fatiando/pooch/raw/{}/data/tiny-data.txt"
+    >>> url = url.format(check_version(__version__))
+    >>> downloader = HTTPDownloader()
+    >>> # Not using with Pooch.fetch so no need to pass an instance of Pooch
+    >>> downloader(url=url, output_file="tiny-data.txt", pooch=None)
+    >>> os.path.exists("tiny-data.txt")
+    True
+    >>> with open("tiny-data.txt") as f:
+    ...     print(f.read().strip())
+    # A tiny data file for test purposes only
+    1  2  3  4  5  6
+    >>> os.remove("tiny-data.txt")
+
+    Authentication can be handled by passing a user name and password to
+    :func:`requests.get`. All arguments provided when creating an instance of
+    the class are forwarded to :func:`requests.get`. We'll use
+    ``auth=(username, password)`` to use basic HTTPS authentication. The
+    https://httpbin.org website allows us to make a fake a login request using
+    whatever username and password we provide to it:
+
+    >>> user = "doggo"
+    >>> password = "goodboy"
+    >>> # httpbin will ask for the user and password we provide in the URL
+    >>> url = f"https://httpbin.org/basic-auth/{user}/{password}"
+    >>> # Trying without the login credentials causes an error
+    >>> downloader = HTTPDownloader()
+    >>> try:
+    ...     downloader(url=url, output_file="tiny-data.txt", pooch=None)
+    ... except Exception:
+    ...     print("There was an error!")
+    There was an error!
+    >>> # Pass in the credentials to HTTPDownloader
+    >>> downloader = HTTPDownloader(auth=(user, password))
+    >>> downloader(url=url, output_file="tiny-data.txt", pooch=None)
+    >>> with open("tiny-data.txt") as f:
+    ...     for line in f:
+    ...         print(line.rstrip())
+    {
+      "authenticated": true,
+      "user": "doggo"
+    }
+    >>> os.remove("tiny-data.txt")
+
+    """
+
+    def __init__(self, progressbar=False, chunk_size=1024, **kwargs):
+        self.kwargs = kwargs
+        self.progressbar = progressbar
+        self.chunk_size = chunk_size
+        if self.progressbar is True and tqdm is None:
+            raise ValueError("Missing package 'tqdm' required for progress bars.")
+
+    def __call__(self, url, output_file, pooch):
+        """
+        Download the given URL over HTTP to the given output file.
+
+        Uses :func:`requests.get`.
+
+        Parameters
+        ----------
+        url : str
+            The URL to the file you want to download.
+        output_file : str or file-like object
+            Path (and file name) to which the file will be downloaded.
+        pooch : :class:`~pooch.Pooch`
+            The instance of :class:`~pooch.Pooch` that is calling this method.
+
+        """
+        kwargs = self.kwargs.copy()
+        kwargs.setdefault("stream", True)
+        ispath = not hasattr(output_file, "write")
+        if ispath:
+            output_file = open(output_file, "w+b")
+        try:
+            response = requests.get(url, **kwargs)
+            response.raise_for_status()
+            content = response.iter_content(chunk_size=self.chunk_size)
+            total = int(response.headers.get("content-length", 0))
+            if self.progressbar is True:
+                # Need to use ascii characters on Windows because there isn't
+                # always full unicode support
+                # (see https://github.com/tqdm/tqdm/issues/454)
+                use_ascii = bool(sys.platform == "win32")
+                progress = tqdm(
+                    total=total,
+                    ncols=79,
+                    ascii=use_ascii,
+                    unit="B",
+                    unit_scale=True,
+                    leave=True,
+                )
+            elif self.progressbar:
+                progress = self.progressbar
+                progress.total = total
+            for chunk in content:
+                if chunk:
+                    output_file.write(chunk)
+                    output_file.flush()
+                    if self.progressbar:
+                        # Use the chunk size here because chunk may be much
+                        # larger if the data are decompressed by requests after
+                        # reading (happens with text files).
+                        progress.update(self.chunk_size)
+            # Make sure the progress bar gets filled even if the actual number
+            # is chunks is smaller than expected. This happens when streaming
+            # text files that are compressed by the server when sending (gzip).
+            # Binary files don't experience this.
+            if self.progressbar:
+                progress.reset()
+                progress.update(total)
+                progress.close()
+        finally:
+            if ispath:
+                output_file.close()

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -119,7 +119,9 @@ def test_pooch_local():
     check_tiny_data(fname)
 
 
-@pytest.mark.parametrize("url", [BASEURL, FIGSHAREURL, ZENODOURL], ids=["https", "figshare", "zenodo"])
+@pytest.mark.parametrize(
+    "url", [BASEURL, FIGSHAREURL, ZENODOURL], ids=["https", "figshare", "zenodo"]
+)
 def test_pooch_custom_url(url):
     "Have pooch download the file from URL that is not base_url"
     with TemporaryDirectory() as local_store:
@@ -140,7 +142,9 @@ def test_pooch_custom_url(url):
             assert log_file.getvalue() == ""
 
 
-@pytest.mark.parametrize("url", [BASEURL, FIGSHAREURL, ZENODOURL], ids=["https", "figshare", "zenodo"])
+@pytest.mark.parametrize(
+    "url", [BASEURL, FIGSHAREURL, ZENODOURL], ids=["https", "figshare", "zenodo"]
+)
 def test_pooch_download(url):
     "Setup a pooch that has no local data and needs to download"
     with TemporaryDirectory() as local_store:

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -24,6 +24,7 @@ from ..downloaders import HTTPDownloader
 from .utils import (
     pooch_test_url,
     pooch_test_figshare_url,
+    pooch_test_zenodo_url,
     pooch_test_registry,
     check_tiny_data,
     check_large_data,
@@ -36,6 +37,7 @@ DATA_DIR = str(Path(__file__).parent / "data")
 REGISTRY = pooch_test_registry()
 BASEURL = pooch_test_url()
 FIGSHAREURL = pooch_test_figshare_url()
+ZENODOURL = pooch_test_zenodo_url()
 REGISTRY_CORRUPTED = {
     # The same data file but I changed the hash manually to a wrong one
     "tiny-data.txt": "098h0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d"
@@ -117,7 +119,7 @@ def test_pooch_local():
     check_tiny_data(fname)
 
 
-@pytest.mark.parametrize("url", [BASEURL, FIGSHAREURL], ids=["https", "figshare"])
+@pytest.mark.parametrize("url", [BASEURL, FIGSHAREURL, ZENODOURL], ids=["https", "figshare", "zenodo"])
 def test_pooch_custom_url(url):
     "Have pooch download the file from URL that is not base_url"
     with TemporaryDirectory() as local_store:
@@ -138,7 +140,7 @@ def test_pooch_custom_url(url):
             assert log_file.getvalue() == ""
 
 
-@pytest.mark.parametrize("url", [BASEURL, FIGSHAREURL], ids=["https", "figshare"])
+@pytest.mark.parametrize("url", [BASEURL, FIGSHAREURL, ZENODOURL], ids=["https", "figshare", "zenodo"])
 def test_pooch_download(url):
     "Setup a pooch that has no local data and needs to download"
     with TemporaryDirectory() as local_store:

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -27,7 +27,7 @@ from ..downloaders import (
     HTTPDownloader,
     FTPDownloader,
     SFTPDownloader,
-    FigshareDownloader,
+    DOIDownloader,
     choose_downloader,
     figshare_download_url,
 )
@@ -52,6 +52,13 @@ def test_unsupported_protocol():
         choose_downloader("httpup://some-invalid-url.com")
 
 
+def test_invalid_doi_repository():
+    "Should fail if data repository is not supported"
+    with pytest.raises(ValueError) as exc:
+        DOIDownloader()(url="notarepository://DOI/file_name", output_file=None, pooch=None)
+    assert "Invalid data repository 'notarepository'" in str(exc.value)
+
+
 def test_figshare_url_doi_not_found():
     "Should fail if the DOI is not found on figshare"
     with pytest.raises(ValueError) as exc:
@@ -72,7 +79,7 @@ def test_figshare_downloader():
     "Test figshare downloader"
     # Use the test data we have on figshare
     with TemporaryDirectory() as local_store:
-        downloader = FigshareDownloader()
+        downloader = DOIDownloader()
         outfile = os.path.join(local_store, "tiny-data.txt")
         downloader(FIGSHAREURL + "tiny-data.txt", outfile, None)
         check_tiny_data(outfile)
@@ -133,7 +140,7 @@ def test_downloader_progressbar_fails(downloader):
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")
 @pytest.mark.parametrize(
     "url,downloader",
-    [(BASEURL, HTTPDownloader), (FIGSHAREURL, FigshareDownloader)],
+    [(BASEURL, HTTPDownloader), (FIGSHAREURL, DOIDownloader)],
     ids=["http", "figshare"],
 )
 def test_downloader_progressbar(url, downloader, capsys):

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -114,13 +114,14 @@ def test_downloader_progressbar_fails(downloader):
 
 
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")
-def test_downloader_progressbar(capsys):
+@pytest.mark.parametrize("url", [BASEURL, FIGSHAREURL], ids=["http", "figshare"])
+def test_downloader_progressbar(url, capsys):
     "Setup a downloader function that prints a progress bar for fetch"
     download = HTTPDownloader(progressbar=True)
     with TemporaryDirectory() as local_store:
-        fname = "large-data.txt"
-        url = BASEURL + fname
-        outfile = os.path.join(local_store, "large-data.txt")
+        fname = "tiny-data.txt"
+        url = url + fname
+        outfile = os.path.join(local_store, fname)
         download(url, outfile, None)
         # Read stderr and make sure the progress bar is printed only when told
         captured = capsys.readouterr()
@@ -133,7 +134,7 @@ def test_downloader_progressbar(capsys):
         # Bar size is not always the same so can't reliably test the whole bar.
         assert printed[:25] == progress
         # Check that the downloaded file has the right content
-        check_large_data(outfile)
+        check_tiny_data(outfile)
 
 
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -57,7 +57,7 @@ def test_figshare_downloader():
     with TemporaryDirectory() as local_store:
         downloader = FigshareDownloader()
         outfile = os.path.join(local_store, "tiny-data.txt")
-        downloader(FIGSHAREURL, outfile, None)
+        downloader(FIGSHAREURL + "tiny-data.txt", outfile, None)
         check_tiny_data(outfile)
 
 
@@ -114,10 +114,14 @@ def test_downloader_progressbar_fails(downloader):
 
 
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")
-@pytest.mark.parametrize("url", [BASEURL, FIGSHAREURL], ids=["http", "figshare"])
-def test_downloader_progressbar(url, capsys):
+@pytest.mark.parametrize(
+    "url,downloader",
+    [(BASEURL, HTTPDownloader), (FIGSHAREURL, FigshareDownloader)],
+    ids=["http", "figshare"],
+)
+def test_downloader_progressbar(url, downloader, capsys):
     "Setup a downloader function that prints a progress bar for fetch"
-    download = HTTPDownloader(progressbar=True)
+    download = downloader(progressbar=True)
     with TemporaryDirectory() as local_store:
         fname = "tiny-data.txt"
         url = url + fname

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -29,6 +29,7 @@ from ..downloaders import (
     SFTPDownloader,
     FigshareDownloader,
     choose_downloader,
+    figshare_download_url,
 )
 from .utils import (
     pooch_test_url,
@@ -49,6 +50,22 @@ def test_unsupported_protocol():
     "Should raise ValueError when protocol not in {'https', 'http', 'ftp'}"
     with pytest.raises(ValueError):
         choose_downloader("httpup://some-invalid-url.com")
+
+
+def test_figshare_url_doi_not_found():
+    "Should fail if the DOI is not found on figshare"
+    with pytest.raises(ValueError) as exc:
+        figshare_download_url(doi="NOTAREALDOI", file_name="tiny-data.txt")
+    assert "Is the DOI correct?" in str(exc.value)
+
+
+def test_figshare_url_file_not_found():
+    "Should fail if the DOI is not found on figshare"
+    with pytest.raises(ValueError) as exc:
+        figshare_download_url(
+            doi="10.6084/m9.figshare.14763051.v1", file_name="bla.txt"
+        )
+    assert "File 'bla.txt' not found" in str(exc.value)
 
 
 def test_figshare_downloader():

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -58,7 +58,9 @@ def test_unsupported_protocol():
 def test_invalid_doi_repository():
     "Should fail if data repository is not supported"
     with pytest.raises(ValueError) as exc:
-        DOIDownloader()(url="notarepository://DOI/file_name", output_file=None, pooch=None)
+        DOIDownloader()(
+            url="notarepository://DOI/file_name", output_file=None, pooch=None
+        )
     assert "Invalid data repository 'notarepository'" in str(exc.value)
 
 
@@ -76,7 +78,10 @@ def test_doi_url_not_found(doi_to_url):
 
 @pytest.mark.parametrize(
     "doi_to_url,doi",
-    [(figshare_download_url, "10.6084/m9.figshare.14763051.v1"), (zenodo_download_url, "10.5281/zenodo.4924875")],
+    [
+        (figshare_download_url, "10.6084/m9.figshare.14763051.v1"),
+        (zenodo_download_url, "10.5281/zenodo.4924875"),
+    ],
     ids=["figshare", "zenodo"],
 )
 def test_figshare_url_file_not_found(doi_to_url, doi):

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -27,20 +27,38 @@ from ..downloaders import (
     HTTPDownloader,
     FTPDownloader,
     SFTPDownloader,
+    FigshareDownloader,
     choose_downloader,
 )
-from .utils import pooch_test_url, check_large_data, check_tiny_data, data_over_ftp
+from .utils import (
+    pooch_test_url,
+    check_large_data,
+    check_tiny_data,
+    data_over_ftp,
+    pooch_test_figshare_url,
+)
 
 
 # FTP doesn't work on Travis CI so need to be able to skip tests there
 ON_TRAVIS = bool(os.environ.get("TRAVIS", None))
 BASEURL = pooch_test_url()
+FIGSHAREURL = pooch_test_figshare_url()
 
 
 def test_unsupported_protocol():
     "Should raise ValueError when protocol not in {'https', 'http', 'ftp'}"
     with pytest.raises(ValueError):
         choose_downloader("httpup://some-invalid-url.com")
+
+
+def test_figshare_downloader():
+    "Test figshare downloader"
+    # Use the test data we have on figshare
+    with TemporaryDirectory() as local_store:
+        downloader = FigshareDownloader()
+        outfile = os.path.join(local_store, "tiny-data.txt")
+        downloader(FIGSHAREURL, outfile, None)
+        check_tiny_data(outfile)
 
 
 def test_ftp_downloader(ftpserver):

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -180,21 +180,27 @@ def test_registry_builder_recursive():
         os.remove(outfile.name)
 
 
-def test_parse_url():
+@pytest.mark.parametrize(
+    "url,output",
+    [
+        (
+            "http://127.0.0.1:8080/test.nc",
+            {"protocol": "http", "netloc": "127.0.0.1:8080", "path": "/test.nc"},
+        ),
+        (
+            "ftp://127.0.0.1:8080/test.nc",
+            {"protocol": "ftp", "netloc": "127.0.0.1:8080", "path": "/test.nc"},
+        ),
+        (
+            "figshare://10.6084/m9.figshare.923450.v1/dike.json",
+            {"protocol": "figshare", "netloc": "10.6084/m9.figshare.923450.v1", "path": "/dike.json"},
+        ),
+    ],
+    ids=["http", "ftp", "figshare"],
+)
+def test_parse_url(url, output):
     "Parse URL into 3 components"
-    url = "http://127.0.0.1:8080/test.nc"
-    assert parse_url(url) == {
-        "protocol": "http",
-        "netloc": "127.0.0.1:8080",
-        "path": "/test.nc",
-    }
-
-    url = "ftp://127.0.0.1:8080/test.nc"
-    assert parse_url(url) == {
-        "protocol": "ftp",
-        "netloc": "127.0.0.1:8080",
-        "path": "/test.nc",
-    }
+    assert parse_url(url) == output
 
 
 def test_file_hash_invalid_algorithm():

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -192,23 +192,15 @@ def test_registry_builder_recursive():
             {"protocol": "ftp", "netloc": "127.0.0.1:8080", "path": "/test.nc"},
         ),
         (
-            "figshare://10.6084/m9.figshare.923450.v1/dike.json",
+            "doi:10.6084/m9.figshare.923450.v1/dike.json",
             {
-                "protocol": "figshare",
+                "protocol": "doi",
                 "netloc": "10.6084/m9.figshare.923450.v1",
                 "path": "/dike.json",
             },
         ),
-        (
-            "zenodo://10.5281/zenodo.4924875/dike.json",
-            {
-                "protocol": "zenodo",
-                "netloc": "10.5281/zenodo.4924875",
-                "path": "/dike.json",
-            },
-        ),
     ],
-    ids=["http", "ftp", "figshare", "zenodo"],
+    ids=["http", "ftp", "doi"],
 )
 def test_parse_url(url, output):
     "Parse URL into 3 components"

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -207,6 +207,12 @@ def test_parse_url(url, output):
     assert parse_url(url) == output
 
 
+def test_parse_url_invalid_doi():
+    "Should fail if we forget to not include // in the DOI link"
+    with pytest.raises(ValueError):
+        parse_url("doi://XXX/XXX/fname.txt")
+
+
 def test_file_hash_invalid_algorithm():
     "Test an invalid hashing algorithm"
     with pytest.raises(ValueError) as exc:

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -199,8 +199,16 @@ def test_registry_builder_recursive():
                 "path": "/dike.json",
             },
         ),
+        (
+            "zenodo://10.5281/zenodo.4924875/dike.json",
+            {
+                "protocol": "zenodo",
+                "netloc": "10.5281/zenodo.4924875",
+                "path": "/dike.json",
+            },
+        ),
     ],
-    ids=["http", "ftp", "figshare"],
+    ids=["http", "ftp", "figshare", "zenodo"],
 )
 def test_parse_url(url, output):
     "Parse URL into 3 components"

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -193,7 +193,11 @@ def test_registry_builder_recursive():
         ),
         (
             "figshare://10.6084/m9.figshare.923450.v1/dike.json",
-            {"protocol": "figshare", "netloc": "10.6084/m9.figshare.923450.v1", "path": "/dike.json"},
+            {
+                "protocol": "figshare",
+                "netloc": "10.6084/m9.figshare.923450.v1",
+                "path": "/dike.json",
+            },
         ),
     ],
     ids=["http", "ftp", "figshare"],

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -63,6 +63,23 @@ def pooch_test_url():
     return url
 
 
+def pooch_test_figshare_url():
+    """
+    Get the base URL for the test data stored in figshare.
+
+    The URL contains the DOI for the figshare dataset using the appropriate
+    version for this version of Pooch.
+
+    Returns
+    -------
+    url
+        The URL for pooch's test data.
+
+    """
+    url = "figshare://10.6084/m9.figshare.14763051.v1/tiny-data.txt"
+    return url
+
+
 def pooch_test_registry():
     """
     Get a registry for the test data used in Pooch itself.

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -76,7 +76,7 @@ def pooch_test_figshare_url():
         The URL for pooch's test data.
 
     """
-    url = "figshare://10.6084/m9.figshare.14763051.v1/tiny-data.txt"
+    url = "figshare://10.6084/m9.figshare.14763051.v1/"
     return url
 
 

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -80,6 +80,23 @@ def pooch_test_figshare_url():
     return url
 
 
+def pooch_test_zenodo_url():
+    """
+    Get the base URL for the test data stored in Zenodo.
+
+    The URL contains the DOI for the Zenodo dataset using the appropriate
+    version for this version of Pooch.
+
+    Returns
+    -------
+    url
+        The URL for pooch's test data.
+
+    """
+    url = "zenodo://10.5281/zenodo.4924875/"
+    return url
+
+
 def pooch_test_registry():
     """
     Get a registry for the test data used in Pooch itself.

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -76,7 +76,7 @@ def pooch_test_figshare_url():
         The URL for pooch's test data.
 
     """
-    url = "figshare://10.6084/m9.figshare.14763051.v1/"
+    url = "doi:10.6084/m9.figshare.14763051.v1/"
     return url
 
 
@@ -93,7 +93,7 @@ def pooch_test_zenodo_url():
         The URL for pooch's test data.
 
     """
-    url = "zenodo://10.5281/zenodo.4924875/"
+    url = "doi:10.5281/zenodo.4924875/"
     return url
 
 

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -208,18 +208,27 @@ def parse_url(url):
     Parameters
     ----------
     url : str
-        URL (e.g.: http://127.0.0.1:8080/test.nc, ftp://127.0.0.1:8080/test.nc)
+        URL (e.g.: http://127.0.0.1:8080/test.nc, ftp://127.0.0.1:8080/test.nc,
+        fighare://10.6084/m9.figshare.923450.v1/test.nc)
 
     Returns
     -------
     parsed_url : dict
-        Three components of a URL (e.g., {'protocol': 'http', 'netloc':
-        '127.0.0.1:8080', 'path': '/test.nc'})
+        Three components of a URL (e.g.,
+        ``{'protocol':'http', 'netloc':'127.0.0.1:8080','path': '/test.nc'}``).
+        In the case of "figshare" URLs, the netloc is the DOI.
 
     """
     parsed_url = urlsplit(url)
     protocol = parsed_url.scheme or "file"
-    return {"protocol": protocol, "netloc": parsed_url.netloc, "path": parsed_url.path}
+    netloc = parsed_url.netloc
+    path = parsed_url.path
+    # The DOI has a / that gets put into the path when it should be in the
+    # netloc. Need to correct for this to make the DOI easily accessible.
+    if protocol == "figshare":
+        netloc = "/".join([netloc, path.split("/")[1]])
+        path = "/" + "/".join(path.split("/")[2:])
+    return {"protocol": protocol, "netloc": netloc, "path": path}
 
 
 def cache_location(path, env=None, version=None):

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -226,6 +226,10 @@ def parse_url(url):
         ``{'protocol':'http', 'netloc':'127.0.0.1:8080','path': '/test.nc'}``).
 
     """
+    if url.startswith("doi://"):
+        raise ValueError(
+            f"Invalid DOI link '{url}'. You must not use '//' after 'doi:'."
+        )
     if url.startswith("doi:"):
         protocol = "doi"
         parts = url[4:].split("/")
@@ -236,11 +240,6 @@ def parse_url(url):
         protocol = parsed_url.scheme or "file"
         netloc = parsed_url.netloc
         path = parsed_url.path
-    # The DOI has a / that gets put into the path when it should be in the
-    # netloc. Need to correct for this to make the DOI easily accessible.
-    if protocol in {"figshare", "zenodo"}:
-        netloc = "/".join([netloc, path.split("/")[1]])
-        path = "/" + "/".join(path.split("/")[2:])
     return {"protocol": protocol, "netloc": netloc, "path": path}
 
 

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -209,8 +209,10 @@ def parse_url(url):
 
     * http://127.0.0.1:8080/test.nc
     * ftp://127.0.0.1:8080/test.nc
-    * fighare://10.6084/m9.figshare.923450.v1/test.nc
-    * zenodo://10.5281/zenodo.4924875/test.nc
+    * doi:10.6084/m9.figshare.923450.v1/test.nc
+
+    The DOI is a special case. The protocol will be "doi", the netloc will be
+    the DOI, and the path is what comes after the second "/".
 
     Parameters
     ----------
@@ -222,13 +224,18 @@ def parse_url(url):
     parsed_url : dict
         Three components of a URL (e.g.,
         ``{'protocol':'http', 'netloc':'127.0.0.1:8080','path': '/test.nc'}``).
-        In the case of "figshare" or "zenodo" URLs, the netloc is the DOI.
 
     """
-    parsed_url = urlsplit(url)
-    protocol = parsed_url.scheme or "file"
-    netloc = parsed_url.netloc
-    path = parsed_url.path
+    if url.startswith("doi:"):
+        protocol = "doi"
+        parts = url[4:].split("/")
+        netloc = "/".join(parts[:2])
+        path = "/" + "/".join(parts[2:])
+    else:
+        parsed_url = urlsplit(url)
+        protocol = parsed_url.scheme or "file"
+        netloc = parsed_url.netloc
+        path = parsed_url.path
     # The DOI has a / that gets put into the path when it should be in the
     # netloc. Need to correct for this to make the DOI easily accessible.
     if protocol in {"figshare", "zenodo"}:

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -205,18 +205,24 @@ def parse_url(url):
 
     <protocol>://<netloc>/<path>
 
+    Example URLs:
+
+    * http://127.0.0.1:8080/test.nc
+    * ftp://127.0.0.1:8080/test.nc
+    * fighare://10.6084/m9.figshare.923450.v1/test.nc
+    * zenodo://10.5281/zenodo.4924875/test.nc
+
     Parameters
     ----------
     url : str
-        URL (e.g.: http://127.0.0.1:8080/test.nc, ftp://127.0.0.1:8080/test.nc,
-        fighare://10.6084/m9.figshare.923450.v1/test.nc)
+        The URL.
 
     Returns
     -------
     parsed_url : dict
         Three components of a URL (e.g.,
         ``{'protocol':'http', 'netloc':'127.0.0.1:8080','path': '/test.nc'}``).
-        In the case of "figshare" URLs, the netloc is the DOI.
+        In the case of "figshare" or "zenodo" URLs, the netloc is the DOI.
 
     """
     parsed_url = urlsplit(url)
@@ -225,7 +231,7 @@ def parse_url(url):
     path = parsed_url.path
     # The DOI has a / that gets put into the path when it should be in the
     # netloc. Need to correct for this to make the DOI easily accessible.
-    if protocol == "figshare":
+    if protocol in {"figshare", "zenodo"}:
         netloc = "/".join([netloc, path.split("/")[1]])
         path = "/" + "/".join(path.split("/")[2:])
     return {"protocol": protocol, "netloc": netloc, "path": path}


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Add the `DOIDownloader` class to download files directly from figshare and Zenodo DOIs. Uses the public API of each reposiroty to get the actual HTTP download link for the given file, which is then passed to `HTTPDownloader`. Defines the new URL protocol `{repository}://{DOI}/{file name}` so that everything can happen automatically in `Pooch` and `retrieve`. 

One caveat is that we can only download 1 file from the archive and the file name must be specified in the URL. This is because our downloaders are all designed to fetch a single file and save it to a given location. Downloading multiple files would require extensive refactoring of large portions of code. This is something we can probably live with and is already pretty convenient.

The whole process was a lot easier than I expected. I basically only had to add a function that gets the download link using the API. The rest was pretty straight forward. This would serve as a good basis for other data repositories out there with DOIs and public APIs.

Fixes #177 

[Update]: Turns out it was super easy to add Zenodo as well so it's also done 🙂 

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
