### PR TITLE
Run CI jobs on Python version extremes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,16 @@
-# Configuration for publishing archives to PyPI and documentation pages to
-# GitHub Pages using GitHub Actions.
+# Build the documentation and deploy to GitHub Pages using GitHub Actions.
 #
 # NOTE: Pin actions to a specific commit to avoid having the authentication
 # token stolen if the Action is compromised. See the comments and links here:
 # https://github.com/pypa/gh-action-pypi-publish/issues/27
 #
-name: deploy
+name: docs
 
-# Only run for pushes to the master branch and releases.
+# Only build PRs, the master branch, and releases. Pushes to branches will only
+# be built when a PR is opened. This avoids duplicated buids in PRs comming
+# from branches in the origin repository (1 for PR and 1 for push).
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -19,109 +21,38 @@ on:
 # Use bash by default in all jobs
 defaults:
   run:
-    # Using "-l {0}" is necessary for conda environments to be activated
+    # The -l {0} is necessary for conda environments to be activated
     # But this breaks on MacOS if using actions/setup-python:
     # https://github.com/actions/setup-python/issues/132
-    shell: bash
+    shell: bash -l {0}
 
 jobs:
-
   #############################################################################
-  # Publish built wheels and source archives to PyPI and test PyPI
-  pypi:
-    name: PyPI
+  # Build the docs
+  build:
     runs-on: ubuntu-latest
-    # Only publish from the origin repository, not forks
-    if: github.repository_owner == 'fatiando'
-
-    steps:
-
-      # Checks-out your repository under $GITHUB_WORKSPACE
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          # Need to fetch more than the last commit so that versioneer can
-          # create the correct version string. If the number of commits since
-          # the last release is greater than this, the version will still be wrong.
-          # Increase if necessary.
-          fetch-depth: 100
-          # The GitHub token is preserved by default but this job doesn't need
-          # to be able to push to GitHub.
-          persist-credentials: false
-
-      # Need the tags so that versioneer can form a valid version number
-      - name: Fetch git tags
-        run: git fetch origin 'refs/tags/*:refs/tags/*'
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8'
-
-      - name: Install requirements
-        run: python -m pip install setuptools setuptools_scm twine wheel
-
-      - name: List installed packages
-        run: python -m pip freeze
-
-      - name: Don't use local version numbers for TestPyPI uploads
-        if: github.event_name != 'release'
-        run: |
-          # Change setuptools-scm local_scheme to "no-local-version" so the
-          # local part of the version isn't included, making the version string
-          # compatible with Test PyPI.
-          sed --in-place "s/node-and-date/no-local-version/g" setup.py
-
-      - name: Build source and wheel distributions
-        run: |
-          python setup.py sdist bdist_wheel
-          echo ""
-          echo "Generated files:"
-          ls -lh dist/
-
-      - name: Check the archives
-        run: twine check dist/*
-
-      - name: Publish to Test PyPI
-        if: success()
-        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN}}
-          repository_url: https://test.pypi.org/legacy/
-          # Allow existing releases on test PyPI without errors.
-          # NOT TO BE USED in PyPI!
-          skip_existing: true
-
-      - name: Publish to PyPI
-        # Only publish to PyPI when a release triggers the build
-        if: success() && github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN}}
-
-  #############################################################################
-  # Publish the documentation to gh-pages
-  docs:
-    name: docs
-    runs-on: ubuntu-latest
-    # Only publish from the origin repository, not forks
-    if: github.repository == 'fatiando/pooch'
     env:
       REQUIREMENTS: requirements.txt
       REQUIREMENTS_DEV: requirements-dev.txt
       REQUIREMENTS_OPTIONAL: requirements-optional.txt
+      DEPENDENCIES: optional
       INSTALL_EXTRA:
-      DEPENDENCIES:
+      PYTHON: 3.9
 
     steps:
+      # Cancel any previous run of the test job
+      # We pin the commit hash corresponding to v0.5.0, and not pinning the tag
+      # because we are giving full access through the github.token.
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@148d9a848c6acaf90a3ec30bc5062f646f8a4163
+        with:
+          access_token: ${{ github.token }}
 
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # Need to fetch more than the last commit so that versioneer can
+          # Need to fetch more than the last commit so that setuptools-scm can
           # create the correct version string. If the number of commits since
           # the last release is greater than this, the version still be wrong.
           # Increase if necessary.
@@ -130,14 +61,14 @@ jobs:
           # to be able to push to GitHub.
           persist-credentials: false
 
-      # Need the tags so that versioneer can form a valid version number
+      # Need the tags so that setuptools-scm can form a valid version number
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: ${{ env.PYTHON }}
 
       - name: Get the pip cache folder
         id: pip-cache
@@ -201,8 +132,33 @@ jobs:
       - name: Build the documentation
         run: make -C doc clean all
 
+      # Store the docs as a build artifact so we can deploy it later
+      - name: Upload HTML documentation as an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs-${{ github.sha }}
+          path: doc/_build/html
+
+  #############################################################################
+  # Publish the documentation to gh-pages
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'release' || github.event_name == 'push'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Fetch the built docs from the "build" job
+      - name: Download HTML documentation artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: docs-${{ github.sha }}
+          path: doc/_build/html
+
       - name: Checkout the gh-pages branch in a separate folder
-        uses: actions/checkout@28c7f3d2b5162b5ddd3dfd9a45aa55eaf396478b
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           ref: gh-pages
           # Checkout to this folder instead of the current one
@@ -220,38 +176,30 @@ jobs:
               version=dev
           fi
           echo "Deploying version: $version"
-
           # Make the new commit message. Needs to happen before cd into deploy
           # to get the right commit hash.
           message="Deploy $version from $(git rev-parse --short HEAD)"
-
           cd deploy
-
           # Need to have this file so that Github doesn't try to run Jekyll
           touch .nojekyll
-
           # Delete all the files and replace with our new  set
           echo -e "\nRemoving old files from previous builds of ${version}:"
           rm -rvf ${version}
           echo -e "\nCopying HTML files to ${version}:"
           cp -Rvf ../doc/_build/html/ ${version}/
-
           # If this is a new release, update the link from /latest to it
           if [[ "${version}" != "dev" ]]; then
               echo -e "\nSetup link from ${version} to 'latest'."
               rm -f latest
               ln -sf ${version} latest
           fi
-
           # Stage the commit
           git add -A .
           echo -e "\nChanges to be applied:"
           git status
-
           # Configure git to be the GitHub Actions account
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-
           # If this is a dev build and the last commit was from a dev build
           # (detect if "dev" was in the previous commit message), reuse the
           # same commit
@@ -262,10 +210,8 @@ jobs:
               echo -e "\nMaking a new commit:"
               git commit -m "$message"
           fi
-
           # Make the push quiet just in case there is anything that could leak
           # sensitive information.
           echo -e "\nPushing changes to gh-pages."
           git push -fq origin gh-pages 2>&1 >/dev/null
-
           echo -e "\nFinished uploading generated files."

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,95 @@
+# Publish archives to PyPI and TestPyPI using GitHub Actions.
+#
+# NOTE: Pin actions to a specific commit to avoid having the authentication
+# token stolen if the Action is compromised. See the comments and links here:
+# https://github.com/pypa/gh-action-pypi-publish/issues/27
+#
+name: pypi
+
+# Only run for pushes to the master branch and releases.
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - published
+
+# Use bash by default in all jobs
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  #############################################################################
+  # Publish built wheels and source archives to PyPI and test PyPI
+  publish:
+    runs-on: ubuntu-latest
+    # Only publish from the origin repository, not forks
+    if: github.repository_owner == 'fatiando'
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # Need to fetch more than the last commit so that setuptools_scm can
+          # create the correct version string. If the number of commits since
+          # the last release is greater than this, the version will still be
+          # wrong. Increase if necessary.
+          fetch-depth: 100
+          # The GitHub token is preserved by default but this job doesn't need
+          # to be able to push to GitHub.
+          persist-credentials: false
+
+      # Need the tags so that setuptools-scm can form a valid version number
+      - name: Fetch git tags
+        run: git fetch origin 'refs/tags/*:refs/tags/*'
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install requirements
+        run: python -m pip install setuptools setuptools_scm twine wheel
+
+      - name: List installed packages
+        run: python -m pip freeze
+
+      - name: Don't use local version numbers for TestPyPI uploads
+        if: github.event_name != 'release'
+        run: |
+          # Change setuptools-scm local_scheme to "no-local-version" so the
+          # local part of the version isn't included, making the version string
+          # compatible with Test PyPI.
+          sed --in-place "s/node-and-date/no-local-version/g" setup.py
+
+      - name: Build source and wheel distributions
+        run: |
+          python setup.py sdist bdist_wheel
+          echo ""
+          echo "Generated files:"
+          ls -lh dist/
+
+      - name: Check the archives
+        run: twine check dist/*
+
+      - name: Publish to Test PyPI
+        if: success()
+        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN}}
+          repository_url: https://test.pypi.org/legacy/
+          # Allow existing releases on test PyPI without errors.
+          # NOT TO BE USED in PyPI!
+          skip_existing: true
+
+      - name: Publish to PyPI
+        # Only publish to PyPI when a release triggers the build
+        if: success() && github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@bce3b74dbf8cc32833ffba9d15f83425c1a736e0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN}}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install requirements
         run: pip install black
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install requirements
         run: pip install flake8
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install requirements
         run: pip install pylint==2.4.*
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install requirements
         run: pip install pathspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# Configuration for testing and deploying with GitHub Actions
+# Run tests and upload to Codecov with GitHub Actions
 #
 # NOTE: Pin actions to a specific commit to avoid having the authentication
 # token stolen if the Action is compromised. See the comments and links here:
@@ -21,15 +21,12 @@ on:
 # Use bash by default in all jobs
 defaults:
   run:
-    # Using "-l {0}" is necessary for conda environments to be activated
-    # But this breaks on MacOS if using actions/setup-python:
-    # https://github.com/actions/setup-python/issues/132
     shell: bash
 
 jobs:
 
   #############################################################################
-  # Run tests, build the docs, and deploy if needed
+  # Run tests and upload to codecov
   test:
     name: ${{ matrix.os }} py${{ matrix.python }} ${{ matrix.dependencies }}
     runs-on: ${{ matrix.os }}-latest
@@ -39,20 +36,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.6, 3.9]
         # If "optional", will install non-required dependencies in the build
         # environment. Otherwise, only required dependencies are installed.
-        dependencies: [""]
-        include:
-          - os: ubuntu
-            python: 3.8
-            dependencies: optional
-          - os: macos
-            python: 3.8
-            dependencies: optional
-          - os: windows
-            python: 3.8
-            dependencies: optional
+        dependencies: ["", optional]
     env:
       REQUIREMENTS: requirements.txt
       REQUIREMENTS_DEV: requirements-dev.txt
@@ -64,12 +51,19 @@ jobs:
       PYTHON: ${{ matrix.python }}
 
     steps:
+      # Cancel any previous run of the test job
+      # We pin the commit hash corresponding to v0.5.0, and not pinning the tag
+      # because we are giving full access through the github.token.
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@148d9a848c6acaf90a3ec30bc5062f646f8a4163
+        with:
+          access_token: ${{ github.token }}
 
       # Checks-out your repository under $GITHUB_WORKSPACE
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # Need to fetch more than the last commit so that versioneer can
+          # Need to fetch more than the last commit so that setuptools-scm can
           # create the correct version string. If the number of commits since
           # the last release is greater than this, the version still be wrong.
           # Increase if necessary.
@@ -78,7 +72,7 @@ jobs:
           # to be able to push to GitHub.
           persist-credentials: false
 
-      # Need the tags so that versioneer can form a valid version number
+      # Need the tags so that setuptools-scm can form a valid version number
       - name: Fetch git tags
         run: git fetch origin 'refs/tags/*:refs/tags/*'
 
@@ -148,9 +142,6 @@ jobs:
 
       - name: Run the tests
         run: make test
-
-      - name: Build the documentation
-        run: make -C doc clean all
 
       - name: Convert coverage report to XML for codecov
         run: coverage xml


### PR DESCRIPTION
We don't need to run on all versions, just the two end members. Chances
of something not working on a version between the lowest and highest
version supported are pretty much zero. Instead, run with optional
dependencies on both end members as well.

Took this chance to update the CI configuration with latest changes from
the other libraries.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
