### PR TITLE
Move hash functions to their own private module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ lint:
 
 clean:
 	find . -name "*.pyc" -exec rm -v {} \;
+	find . -name "*.orig" -exec rm -v {} \;
 	find . -name ".coverage.*" -exec rm -v {} \;
 	rm -rvf build dist MANIFEST *.egg-info __pycache__ .coverage .cache .pytest_cache $(PROJECT)/_version.py
 	rm -rvf $(TESTDIR) dask-worker-space

--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -8,7 +8,8 @@
 #
 # Import functions/classes to make the API
 from .core import Pooch, create, retrieve
-from .utils import os_cache, file_hash, make_registry, check_version, get_logger
+from .utils import os_cache, check_version, get_logger
+from .hashes import file_hash, make_registry
 from .downloaders import (
     HTTPDownloader,
     FTPDownloader,

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -16,17 +16,17 @@ import ftplib
 
 import requests
 import requests.exceptions
+
+from .hashes import hash_matches, file_hash
 from .utils import (
     check_version,
     parse_url,
     get_logger,
     make_local_storage,
     cache_location,
-    hash_matches,
     temporary_file,
     os_cache,
     unique_file_name,
-    file_hash,
 )
 from .downloaders import choose_downloader
 

--- a/pooch/hashes.py
+++ b/pooch/hashes.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2018 The Pooch Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Calculating and checking file hashes.
+"""
+import hashlib
+import functools
+from pathlib import Path
+
+# From the docs: https://docs.python.org/3/library/hashlib.html#hashlib.new
+#   The named constructors are much faster than new() and should be
+#   preferred.
+# Need to fallback on new() for some algorithms.
+ALGORITHMS_AVAILABLE = {
+    alg: getattr(hashlib, alg, functools.partial(hashlib.new, alg))
+    for alg in hashlib.algorithms_available
+}
+
+try:
+    import xxhash
+
+    # xxhash doesn't have a list of available algorithms yet.
+    # https://github.com/ifduyue/python-xxhash/issues/48
+    ALGORITHMS_AVAILABLE.update(
+        {
+            alg: getattr(xxhash, alg, None)
+            for alg in ["xxh128", "xxh64", "xxh32", "xxh3_128", "xxh3_64"]
+        }
+    )
+    # The xxh3 algorithms are only available for version>=2.0. Set to None and
+    # remove to ensure backwards compatibility.
+    ALGORITHMS_AVAILABLE = {
+        alg: func for alg, func in ALGORITHMS_AVAILABLE.items() if func is not None
+    }
+except ImportError:
+    pass
+
+
+def file_hash(fname, alg="sha256"):
+    """
+    Calculate the hash of a given file.
+
+    Useful for checking if a file has changed or been corrupted.
+
+    Parameters
+    ----------
+    fname : str
+        The name of the file.
+    alg : str
+        The type of the hashing algorithm
+
+    Returns
+    -------
+    hash : str
+        The hash of the file.
+
+    Examples
+    --------
+
+    >>> fname = "test-file-for-hash.txt"
+    >>> with open(fname, "w") as f:
+    ...     __ = f.write("content of the file")
+    >>> print(file_hash(fname))
+    0fc74468e6a9a829f103d069aeb2bb4f8646bad58bf146bb0e3379b759ec4a00
+    >>> import os
+    >>> os.remove(fname)
+
+    """
+    if alg not in ALGORITHMS_AVAILABLE:
+        raise ValueError(
+            f"Algorithm '{alg}' not available to the pooch library. "
+            "Only the following algorithms are available "
+            f"{list(ALGORITHMS_AVAILABLE.keys())}."
+        )
+    # Calculate the hash in chunks to avoid overloading the memory
+    chunksize = 65536
+    hasher = ALGORITHMS_AVAILABLE[alg]()
+    with open(fname, "rb") as fin:
+        buff = fin.read(chunksize)
+        while buff:
+            hasher.update(buff)
+            buff = fin.read(chunksize)
+    return hasher.hexdigest()
+
+
+def hash_algorithm(hash_string):
+    """
+    Parse the name of the hash method from the hash string.
+
+    The hash string should have the following form ``algorithm:hash``, where
+    algorithm can be the name of any algorithm known to :mod:`hashlib`.
+
+    If the algorithm is omitted or the hash string is None, will default to
+    ``"sha256"``.
+
+    Parameters
+    ----------
+    hash_string : str
+        The hash string with optional algorithm prepended.
+
+    Returns
+    -------
+    hash_algorithm : str
+        The name of the algorithm.
+
+    Examples
+    --------
+
+    >>> print(hash_algorithm("qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
+    sha256
+    >>> print(hash_algorithm("md5:qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
+    md5
+    >>> print(hash_algorithm("sha256:qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
+    sha256
+    >>> print(hash_algorithm("SHA256:qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
+    sha256
+    >>> print(hash_algorithm("xxh3_64:qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
+    xxh3_64
+    >>> print(hash_algorithm(None))
+    sha256
+
+    """
+    default = "sha256"
+    if hash_string is None:
+        algorithm = default
+    elif ":" not in hash_string:
+        algorithm = default
+    else:
+        algorithm = hash_string.split(":")[0]
+    return algorithm.lower()
+
+
+def hash_matches(fname, known_hash, strict=False, source=None):
+    """
+    Check if the hash of a file matches a known hash.
+
+    If the *known_hash* is None, will always return True.
+
+    Coverts hashes to lowercase before comparison to avoid system specific
+    mismatches between hashes in the registry and computed hashes.
+
+    Parameters
+    ----------
+    fname : str or PathLike
+        The path to the file.
+    known_hash : str
+        The known hash. Optionally, prepend ``alg:`` to the hash to specify the
+        hashing algorithm. Default is SHA256.
+    strict : bool
+        If True, will raise a :class:`ValueError` if the hash does not match
+        informing the user that the file may be corrupted.
+    source : str
+        The source of the downloaded file (name or URL, for example). Will be
+        used in the error message if *strict* is True. Has no other use other
+        than reporting to the user where the file came from in case of hash
+        mismatch. If None, will default to *fname*.
+
+    Returns
+    -------
+    is_same : bool
+        True if the hash matches, False otherwise.
+
+    """
+    if known_hash is None:
+        return True
+    algorithm = hash_algorithm(known_hash)
+    new_hash = file_hash(fname, alg=algorithm)
+    matches = new_hash.lower() == known_hash.split(":")[-1].lower()
+    if strict and not matches:
+        if source is None:
+            source = str(fname)
+        raise ValueError(
+            f"{algorithm.upper()} hash of downloaded file ({source}) does not match"
+            f" the known hash: expected {known_hash} but got {new_hash}. Deleted"
+            " download for safety. The downloaded file may have been corrupted or"
+            " the known hash may be outdated."
+        )
+    return matches
+
+
+def make_registry(directory, output, recursive=True):
+    """
+    Make a registry of files and hashes for the given directory.
+
+    This is helpful if you have many files in your test dataset as it keeps you
+    from needing to manually update the registry.
+
+    Parameters
+    ----------
+    directory : str
+        Directory of the test data to put in the registry. All file names in
+        the registry will be relative to this directory.
+    output : str
+        Name of the output registry file.
+    recursive : bool
+        If True, will recursively look for files in subdirectories of
+        *directory*.
+
+    """
+    directory = Path(directory)
+    if recursive:
+        pattern = "**/*"
+    else:
+        pattern = "*"
+
+    files = sorted(
+        [
+            str(path.relative_to(directory))
+            for path in directory.glob(pattern)
+            if path.is_file()
+        ]
+    )
+
+    hashes = [file_hash(str(directory / fname)) for fname in files]
+
+    with open(output, "w") as outfile:
+        for fname, fhash in zip(files, hashes):
+            # Only use Unix separators for the registry so that we don't go
+            # insane dealing with file paths.
+            outfile.write("{} {}\n".format(fname.replace("\\", "/"), fhash))

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -15,7 +15,8 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from ..core import Pooch, retrieve, download_action, stream_download
-from ..utils import file_hash, get_logger, temporary_file, os_cache, hash_matches
+from ..utils import get_logger, temporary_file, os_cache
+from ..hashes import file_hash, hash_matches
 
 # Import the core module so that we can monkeypatch some functions
 from .. import core

--- a/pooch/tests/test_hashes.py
+++ b/pooch/tests/test_hashes.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2018 The Pooch Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+"""
+Test the hash calculation and checking functions.
+"""
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from ..core import Pooch
+from ..hashes import (
+    make_registry,
+    file_hash,
+    hash_matches,
+)
+from .utils import check_tiny_data
+
+DATA_DIR = str(Path(__file__).parent / "data" / "store")
+REGISTRY = (
+    "tiny-data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d\n"
+)
+REGISTRY_RECURSIVE = (
+    "subdir/tiny-data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d\n"
+    "tiny-data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d\n"
+)
+TINY_DATA_HASHES_HASHLIB = {
+    "sha1": "c03148994acd89317915ea2f2d080d6dd127aa09",
+    "sha256": "baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d",
+    "md5": "70e2afd3fd7e336ae478b1e740a5f08e",
+}
+TINY_DATA_HASHES_XXH = {
+    "xxh128": "0267d220db258fffb0c567c0ecd1b689",
+    "xxh3_128": "0267d220db258fffb0c567c0ecd1b689",
+    "xxh64": "f843815fe57948fa",
+    "xxh3_64": "811e3f2a12aec53f",
+    "xxh32": "98d6f1a2",
+}
+TINY_DATA_HASHES = TINY_DATA_HASHES_HASHLIB.copy()
+TINY_DATA_HASHES.update(TINY_DATA_HASHES_XXH)
+
+
+def test_make_registry():
+    "Check that the registry builder creates the right file names and hashes"
+    outfile = NamedTemporaryFile(delete=False)
+    # Need to close the file before writing to it.
+    outfile.close()
+    try:
+        make_registry(DATA_DIR, outfile.name, recursive=False)
+        with open(outfile.name) as fout:
+            registry = fout.read()
+        assert registry == REGISTRY
+        # Check that the registry can be used.
+        pup = Pooch(path=DATA_DIR, base_url="some bogus URL", registry={})
+        pup.load_registry(outfile.name)
+        true = os.path.join(DATA_DIR, "tiny-data.txt")
+        fname = pup.fetch("tiny-data.txt")
+        assert true == fname
+        check_tiny_data(fname)
+    finally:
+        os.remove(outfile.name)
+
+
+def test_make_registry_recursive():
+    "Check that the registry builder works in recursive mode"
+    outfile = NamedTemporaryFile(delete=False)
+    # Need to close the file before writing to it.
+    outfile.close()
+    try:
+        make_registry(DATA_DIR, outfile.name, recursive=True)
+        with open(outfile.name) as fout:
+            registry = fout.read()
+        assert registry == REGISTRY_RECURSIVE
+        # Check that the registry can be used.
+        pup = Pooch(path=DATA_DIR, base_url="some bogus URL", registry={})
+        pup.load_registry(outfile.name)
+        assert os.path.join(DATA_DIR, "tiny-data.txt") == pup.fetch("tiny-data.txt")
+        check_tiny_data(pup.fetch("tiny-data.txt"))
+        true = os.path.join(DATA_DIR, "subdir", "tiny-data.txt")
+        assert true == pup.fetch("subdir/tiny-data.txt")
+        check_tiny_data(pup.fetch("subdir/tiny-data.txt"))
+    finally:
+        os.remove(outfile.name)
+
+
+def test_file_hash_invalid_algorithm():
+    "Test an invalid hashing algorithm"
+    with pytest.raises(ValueError) as exc:
+        file_hash(fname="something", alg="blah")
+    assert "'blah'" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "alg,expected_hash",
+    list(TINY_DATA_HASHES.items()),
+    ids=list(TINY_DATA_HASHES.keys()),
+)
+def test_file_hash(alg, expected_hash):
+    "Test the hash calculation using hashlib and xxhash"
+    if alg.startswith("xxh"):
+        pytest.importorskip("xxhash")
+    fname = os.path.join(DATA_DIR, "tiny-data.txt")
+    check_tiny_data(fname)
+    returned_hash = file_hash(fname, alg)
+    assert returned_hash == expected_hash
+
+
+@pytest.mark.parametrize(
+    "alg,expected_hash",
+    list(TINY_DATA_HASHES.items()),
+    ids=list(TINY_DATA_HASHES.keys()),
+)
+def test_hash_matches(alg, expected_hash):
+    "Make sure the hash checking function works"
+    if alg.startswith("xxh"):
+        pytest.importorskip("xxhash")
+    fname = os.path.join(DATA_DIR, "tiny-data.txt")
+    check_tiny_data(fname)
+    # Check if the check passes
+    known_hash = f"{alg}:{expected_hash}"
+    assert hash_matches(fname, known_hash)
+    # And also if it fails
+    known_hash = f"{alg}:blablablabla"
+    assert not hash_matches(fname, known_hash)
+
+
+@pytest.mark.parametrize(
+    "alg,expected_hash",
+    list(TINY_DATA_HASHES_HASHLIB.items()),
+    ids=list(TINY_DATA_HASHES_HASHLIB.keys()),
+)
+def test_hash_matches_strict(alg, expected_hash):
+    "Make sure the hash checking function raises an exception if strict"
+    fname = os.path.join(DATA_DIR, "tiny-data.txt")
+    check_tiny_data(fname)
+    # Check if the check passes
+    known_hash = f"{alg}:{expected_hash}"
+    assert hash_matches(fname, known_hash, strict=True)
+    # And also if it fails
+    bad_hash = f"{alg}:blablablabla"
+    with pytest.raises(ValueError) as error:
+        hash_matches(fname, bad_hash, strict=True, source="Neverland")
+    assert "Neverland" in str(error.value)
+    with pytest.raises(ValueError) as error:
+        hash_matches(fname, bad_hash, strict=True, source=None)
+    assert fname in str(error.value)
+
+
+def test_hash_matches_none():
+    "The hash checking function should always returns True if known_hash=None"
+    fname = os.path.join(DATA_DIR, "tiny-data.txt")
+    assert hash_matches(fname, known_hash=None)
+    # Should work even if the file is invalid
+    assert hash_matches(fname="", known_hash=None)
+    # strict should cause an error if this wasn't working
+    assert hash_matches(fname, known_hash=None, strict=True)
+
+
+@pytest.mark.parametrize(
+    "alg,expected_hash",
+    list(TINY_DATA_HASHES_HASHLIB.items()),
+    ids=list(TINY_DATA_HASHES_HASHLIB.keys()),
+)
+def test_hash_matches_uppercase(alg, expected_hash):
+    "Hash matching should be independent of upper or lower case"
+    fname = os.path.join(DATA_DIR, "tiny-data.txt")
+    check_tiny_data(fname)
+    # Check if the check passes
+    known_hash = f"{alg}:{expected_hash.upper()}"
+    assert hash_matches(fname, known_hash, strict=True)
+    # And also if it fails
+    with pytest.raises(ValueError) as error:
+        hash_matches(fname, known_hash[:-5], strict=True, source="Neverland")
+    assert "Neverland" in str(error.value)

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -10,42 +10,13 @@ Misc utilities
 import logging
 import os
 import tempfile
-from pathlib import Path
 import hashlib
+from pathlib import Path
 from urllib.parse import urlsplit
 from contextlib import contextmanager
-import functools
 
 import appdirs
 from packaging.version import Version
-
-# From the docs: https://docs.python.org/3/library/hashlib.html#hashlib.new
-#   The named constructors are much faster than new() and should be
-#   preferred.
-# Need to fallback on new() for some algorithms.
-ALGORITHMS_AVAILABLE = {
-    alg: getattr(hashlib, alg, functools.partial(hashlib.new, alg))
-    for alg in hashlib.algorithms_available
-}
-
-try:
-    import xxhash
-
-    # xxhash doesn't have a list of available algorithms yet.
-    # https://github.com/ifduyue/python-xxhash/issues/48
-    ALGORITHMS_AVAILABLE.update(
-        {
-            alg: getattr(xxhash, alg, None)
-            for alg in ["xxh128", "xxh64", "xxh32", "xxh3_128", "xxh3_64"]
-        }
-    )
-    # The xxh3 algorithms are only available for version>=2.0. Set to None and
-    # remove to ensure backwards compatibility.
-    ALGORITHMS_AVAILABLE = {
-        alg: func for alg, func in ALGORITHMS_AVAILABLE.items() if func is not None
-    }
-except ImportError:
-    pass
 
 
 LOGGER = logging.Logger("pooch")
@@ -97,53 +68,6 @@ def os_cache(project):
     return Path(appdirs.user_cache_dir(project))
 
 
-def file_hash(fname, alg="sha256"):
-    """
-    Calculate the hash of a given file.
-
-    Useful for checking if a file has changed or been corrupted.
-
-    Parameters
-    ----------
-    fname : str
-        The name of the file.
-    alg : str
-        The type of the hashing algorithm
-
-    Returns
-    -------
-    hash : str
-        The hash of the file.
-
-    Examples
-    --------
-
-    >>> fname = "test-file-for-hash.txt"
-    >>> with open(fname, "w") as f:
-    ...     __ = f.write("content of the file")
-    >>> print(file_hash(fname))
-    0fc74468e6a9a829f103d069aeb2bb4f8646bad58bf146bb0e3379b759ec4a00
-    >>> import os
-    >>> os.remove(fname)
-
-    """
-    if alg not in ALGORITHMS_AVAILABLE:
-        raise ValueError(
-            f"Algorithm '{alg}' not available to the pooch library. "
-            "Only the following algorithms are available "
-            f"{list(ALGORITHMS_AVAILABLE.keys())}."
-        )
-    # Calculate the hash in chunks to avoid overloading the memory
-    chunksize = 65536
-    hasher = ALGORITHMS_AVAILABLE[alg]()
-    with open(fname, "rb") as fin:
-        buff = fin.read(chunksize)
-        while buff:
-            hasher.update(buff)
-            buff = fin.read(chunksize)
-    return hasher.hexdigest()
-
-
 def check_version(version, fallback="master"):
     """
     Check if a version is PEP440 compliant and there are no unreleased changes.
@@ -188,48 +112,6 @@ def check_version(version, fallback="master"):
     if parse.local is not None:
         return fallback
     return version
-
-
-def make_registry(directory, output, recursive=True):
-    """
-    Make a registry of files and hashes for the given directory.
-
-    This is helpful if you have many files in your test dataset as it keeps you
-    from needing to manually update the registry.
-
-    Parameters
-    ----------
-    directory : str
-        Directory of the test data to put in the registry. All file names in
-        the registry will be relative to this directory.
-    output : str
-        Name of the output registry file.
-    recursive : bool
-        If True, will recursively look for files in subdirectories of
-        *directory*.
-
-    """
-    directory = Path(directory)
-    if recursive:
-        pattern = "**/*"
-    else:
-        pattern = "*"
-
-    files = sorted(
-        [
-            str(path.relative_to(directory))
-            for path in directory.glob(pattern)
-            if path.is_file()
-        ]
-    )
-
-    hashes = [file_hash(str(directory / fname)) for fname in files]
-
-    with open(output, "w") as outfile:
-        for fname, fhash in zip(files, hashes):
-            # Only use Unix separators for the registry so that we don't go
-            # insane dealing with file paths.
-            outfile.write("{} {}\n".format(fname.replace("\\", "/"), fhash))
 
 
 def parse_url(url):
@@ -349,99 +231,6 @@ def make_local_storage(path, env=None):
                 f"Use environment variable '{env}' to specify a different location."
             )
         raise PermissionError(" ".join(message)) from error
-
-
-def hash_algorithm(hash_string):
-    """
-    Parse the name of the hash method from the hash string.
-
-    The hash string should have the following form ``algorithm:hash``, where
-    algorithm can be the name of any algorithm known to :mod:`hashlib`.
-
-    If the algorithm is omitted or the hash string is None, will default to
-    ``"sha256"``.
-
-    Parameters
-    ----------
-    hash_string : str
-        The hash string with optional algorithm prepended.
-
-    Returns
-    -------
-    hash_algorithm : str
-        The name of the algorithm.
-
-    Examples
-    --------
-
-    >>> print(hash_algorithm("qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
-    sha256
-    >>> print(hash_algorithm("md5:qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
-    md5
-    >>> print(hash_algorithm("sha256:qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
-    sha256
-    >>> print(hash_algorithm("SHA256:qouuwhwd2j192y1lb1iwgowdj2898wd2d9"))
-    sha256
-    >>> print(hash_algorithm(None))
-    sha256
-
-    """
-    default = "sha256"
-    if hash_string is None:
-        algorithm = default
-    elif ":" not in hash_string:
-        algorithm = default
-    else:
-        algorithm = hash_string.split(":")[0]
-    return algorithm.lower()
-
-
-def hash_matches(fname, known_hash, strict=False, source=None):
-    """
-    Check if the hash of a file matches a known hash.
-
-    If the *known_hash* is None, will always return True.
-
-    Coverts hashes to lowercase before comparison to avoid system specific
-    mismatches between hashes in the registry and computed hashes.
-
-    Parameters
-    ----------
-    fname : str or PathLike
-        The path to the file.
-    known_hash : str
-        The known hash. Optionally, prepend ``alg:`` to the hash to specify the
-        hashing algorithm. Default is SHA256.
-    strict : bool
-        If True, will raise a :class:`ValueError` if the hash does not match
-        informing the user that the file may be corrupted.
-    source : str
-        The source of the downloaded file (name or URL, for example). Will be
-        used in the error message if *strict* is True. Has no other use other
-        than reporting to the user where the file came from in case of hash
-        mismatch. If None, will default to *fname*.
-
-    Returns
-    -------
-    is_same : bool
-        True if the hash matches, False otherwise.
-
-    """
-    if known_hash is None:
-        return True
-    algorithm = hash_algorithm(known_hash)
-    new_hash = file_hash(fname, alg=algorithm)
-    matches = new_hash.lower() == known_hash.split(":")[-1].lower()
-    if strict and not matches:
-        if source is None:
-            source = str(fname)
-        raise ValueError(
-            f"{algorithm.upper()} hash of downloaded file ({source}) does not match"
-            f" the known hash: expected {known_hash} but got {new_hash}. Deleted"
-            " download for safety. The downloaded file may have been corrupted or"
-            " the known hash may be outdated."
-        )
-    return matches
 
 
 @contextmanager


### PR DESCRIPTION
There are a few of these functions so they should be in their own
module. The API is unchanged, this is just internal organization. Took
this chance to unify and better parametrize the hash tests.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
