### PR TITLE
Use a custom pytest mark for tests accessing the network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ doc/api/generated
 MANIFEST
 .coverage.*
 pooch/_version.py
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ doc/api/generated
 MANIFEST
 .coverage.*
 pooch/_version.py
+.idea

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,3 +18,4 @@ order by last name) and are considered "The Pooch Developers":
 * [Santiago Soler](https://github.com/santisoler) - CONICET, Argentina; Instituto Geofísico Sismológico Volponi, Universidad Nacional de San Juan, Argentina (ORCID: [0000-0001-9202-5317](https://www.orcid.org/0000-0001-9202-5317))
 * [Matthew Turk](https://github.com/matthewturk) - University of Illinois at Urbana-Champaign, USA (ORCID: [0000-0002-5294-0198](https://www.orcid.org/0000-0002-5294-0198))
 * [Leonardo Uieda](https://github.com/leouieda) - University of Liverpool, UK (ORCID: [0000-0001-6123-9515](https://www.orcid.org/0000-0001-6123-9515))
+* [Antonio Valentino](https://github.com/avalentino)

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -45,6 +45,7 @@ REGISTRY_CORRUPTED = {
 }
 
 
+@pytest.mark.network
 def test_retrieve():
     "Try downloading some data with retrieve"
     with TemporaryDirectory() as local_store:
@@ -70,6 +71,7 @@ def test_retrieve():
             assert log_file.getvalue() == ""
 
 
+@pytest.mark.network
 def test_retrieve_fname():
     "Try downloading some data with retrieve and setting the file name"
     with TemporaryDirectory() as local_store:
@@ -88,6 +90,7 @@ def test_retrieve_fname():
         assert file_hash(fname) == REGISTRY[data_file]
 
 
+@pytest.mark.network
 def test_retrieve_default_path():
     "Try downloading some data with retrieve to the default cache location"
     data_file = "tiny-data.txt"
@@ -120,6 +123,7 @@ def test_pooch_local():
     check_tiny_data(fname)
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     "url", [BASEURL, FIGSHAREURL, ZENODOURL], ids=["https", "figshare", "zenodo"]
 )
@@ -143,6 +147,7 @@ def test_pooch_custom_url(url):
             assert log_file.getvalue() == ""
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     "url", [BASEURL, FIGSHAREURL, ZENODOURL], ids=["https", "figshare", "zenodo"]
 )
@@ -185,6 +190,7 @@ class FakeHashMatches:  # pylint: disable=too-few-public-methods
         return hash_matches(*args, **kwargs)
 
 
+@pytest.mark.network
 def test_pooch_download_retry_off_by_default(monkeypatch):
     "Check that retrying the download is off by default"
     with TemporaryDirectory() as local_store:
@@ -215,6 +221,7 @@ class FakeSleep:  # pylint: disable=too-few-public-methods
         self.times.append(secs)
 
 
+@pytest.mark.network
 def test_pooch_download_retry(monkeypatch):
     "Check that retrying the download works if the hash is different"
     with TemporaryDirectory() as local_store:
@@ -247,6 +254,7 @@ def test_pooch_download_retry(monkeypatch):
         assert file_hash(fname) == REGISTRY["tiny-data.txt"]
 
 
+@pytest.mark.network
 def test_pooch_download_retry_fails_eventually(monkeypatch):
     "Check that retrying the download fails after the set amount of retries"
     with TemporaryDirectory() as local_store:
@@ -268,6 +276,7 @@ def test_pooch_download_retry_fails_eventually(monkeypatch):
         assert "does not match the known hash" in str(error)
 
 
+@pytest.mark.network
 def test_pooch_logging_level():
     "Setup a pooch and check that no logging happens when the level is raised"
     with TemporaryDirectory() as local_store:
@@ -282,6 +291,7 @@ def test_pooch_logging_level():
         check_tiny_data(fname)
 
 
+@pytest.mark.network
 def test_pooch_update():
     "Setup a pooch that already has the local data but the file is outdated"
     with TemporaryDirectory() as local_store:
@@ -309,6 +319,7 @@ def test_pooch_update():
             assert log_file.getvalue() == ""
 
 
+@pytest.mark.network
 def test_pooch_corrupted():
     "Raise an exception if the file hash doesn't match the registry"
     # Test the case where the file wasn't in the directory
@@ -392,6 +403,7 @@ def test_pooch_load_registry_invalid_line():
         pup.load_registry(os.path.join(DATA_DIR, "registry-invalid.txt"))
 
 
+@pytest.mark.network
 def test_check_availability():
     "Should correctly check availability of existing and non existing files"
     # Check available remote file
@@ -408,6 +420,7 @@ def test_check_availability():
 
 
 # https://blog.travis-ci.com/2018-07-23-the-tale-of-ftp-at-travis-ci
+@pytest.mark.network
 @pytest.mark.skipif(ON_TRAVIS, reason="FTP is not allowed on Travis CI")
 def test_check_availability_on_ftp():
     "Should correctly check availability of existing and non existing files"
@@ -425,6 +438,7 @@ def test_check_availability_on_ftp():
     assert not pup.is_available("doesnot_exist.zip")
 
 
+@pytest.mark.network
 def test_fetch_with_downloader(capsys):
     "Setup a downloader function for fetch"
 
@@ -502,6 +516,7 @@ def test_download_action():
     assert verb == "Fetching"
 
 
+@pytest.mark.network
 @pytest.mark.parametrize("fname", ["tiny-data.txt", "subdir/tiny-data.txt"])
 def test_stream_download(fname):
     "Check that downloading a file over HTTP works as expected"

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -103,6 +103,7 @@ def test_doi_downloader(url):
         check_tiny_data(outfile)
 
 
+@pytest.mark.network
 def test_ftp_downloader(ftpserver):
     "Test ftp downloader"
     with data_over_ftp(ftpserver, "tiny-data.txt") as url:
@@ -113,6 +114,7 @@ def test_ftp_downloader(ftpserver):
             check_tiny_data(outfile)
 
 
+@pytest.mark.network
 @pytest.mark.skipif(paramiko is None, reason="requires paramiko to run SFTP")
 @pytest.mark.skipif(ON_TRAVIS, reason="SFTP is not allowed on Travis CI")
 def test_sftp_downloader():
@@ -125,6 +127,7 @@ def test_sftp_downloader():
         assert os.path.exists(outfile)
 
 
+@pytest.mark.network
 @pytest.mark.skipif(paramiko is None, reason="requires paramiko to run SFTP")
 @pytest.mark.skipif(ON_TRAVIS, reason="SFTP is not allowed on Travis CI")
 def test_sftp_downloader_fail_if_file_object():
@@ -155,6 +158,7 @@ def test_downloader_progressbar_fails(downloader):
     assert "'tqdm'" in str(exc.value)
 
 
+@pytest.mark.network
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")
 @pytest.mark.parametrize(
     "url,downloader",
@@ -183,6 +187,7 @@ def test_downloader_progressbar(url, downloader, capsys):
         check_tiny_data(outfile)
 
 
+@pytest.mark.network
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")
 def test_downloader_progressbar_ftp(capsys, ftpserver):
     "Setup an FTP downloader function that prints a progress bar for fetch"
@@ -207,6 +212,7 @@ def test_downloader_progressbar_ftp(capsys, ftpserver):
             check_tiny_data(outfile)
 
 
+@pytest.mark.network
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")
 @pytest.mark.skipif(paramiko is None, reason="requires paramiko")
 @pytest.mark.skipif(ON_TRAVIS, reason="SFTP is not allowed on Travis CI")
@@ -231,6 +237,7 @@ def test_downloader_progressbar_sftp(capsys):
         assert os.path.exists(outfile)
 
 
+@pytest.mark.network
 def test_downloader_arbitrary_progressbar(capsys):
     "Setup a downloader function with an arbitrary progress bar class."
 

--- a/pooch/tests/test_integration.py
+++ b/pooch/tests/test_integration.py
@@ -12,11 +12,14 @@ import os
 import shutil
 from pathlib import Path
 
+import pytest
+
 from .. import create, os_cache
 from .. import __version__ as full_version
 from .utils import check_tiny_data, capture_log
 
 
+@pytest.mark.network
 def test_create_and_fetch():
     "Fetch a data file from the local storage"
     path = os_cache("pooch-testing")

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -23,6 +23,7 @@ REGISTRY = pooch_test_registry()
 BASEURL = pooch_test_url()
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     "method,ext,name",
     [
@@ -65,6 +66,7 @@ def test_decompress(method, ext, name):
         check_tiny_data(fname)
 
 
+@pytest.mark.network
 def test_decompress_fails():
     "Should fail if method='auto' and no extension is given in the file name"
     with TemporaryDirectory() as local_store:
@@ -95,6 +97,7 @@ def test_decompress_fails():
         assert "pooch.Unzip/Untar" in exception.value.args[0]
 
 
+@pytest.mark.network
 def test_extractprocessor_fails():
     "The base class should be used and should fail when passed to fecth"
     with TemporaryDirectory() as local_store:
@@ -110,6 +113,7 @@ def test_extractprocessor_fails():
         assert not exception.value.args
 
 
+@pytest.mark.network
 @pytest.mark.parametrize("_dir", [None, "foo"], ids=["default_dir", "custom_dir"])
 @pytest.mark.parametrize(
     "proc_cls,file_ext,msg",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 markers =
-    network: test access the network
+    network: test requires network access

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    network: test access the network


### PR DESCRIPTION
A custom pytest mark is applied to all unittests accessing the network so that it is now easier to skip them in environments where the network is not accessible.
Closes #247, closes #250.

**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
