### PR TITLE
Never write into the source data directory

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,3 +18,4 @@ order by last name) and are considered "The Pooch Developers":
 * [Santiago Soler](https://github.com/santisoler) - CONICET, Argentina; Instituto Geofísico Sismológico Volponi, Universidad Nacional de San Juan, Argentina (ORCID: [0000-0001-9202-5317](https://www.orcid.org/0000-0001-9202-5317))
 * [Matthew Turk](https://github.com/matthewturk) - University of Illinois at Urbana-Champaign, USA (ORCID: [0000-0002-5294-0198](https://www.orcid.org/0000-0002-5294-0198))
 * [Leonardo Uieda](https://github.com/leouieda) - University of Liverpool, UK (ORCID: [0000-0001-6123-9515](https://www.orcid.org/0000-0001-6123-9515))
+* [Antonio Valentino](https://github.com/avalentino)

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -48,6 +48,10 @@ REGISTRY_CORRUPTED = {
 
 @pytest.fixture
 def pooch_tmp_path(tmp_path):
+    """
+    Mirror the test data folder on a temporary directory. Needed to avoid
+    permission errors when pooch is installed on a non-writable path.
+    """
     return make_tmp_path(DATA_DIR, tmp_path)
 
 

--- a/pooch/tests/test_hashes.py
+++ b/pooch/tests/test_hashes.py
@@ -47,6 +47,10 @@ TINY_DATA_HASHES.update(TINY_DATA_HASHES_XXH)
 
 @pytest.fixture
 def pooch_tmp_path(tmp_path):
+    """
+    Mirror the test data folder on a temporary directory. Needed to avoid
+    permission errors when pooch is installed on a non-writable path.
+    """
     return make_tmp_path(DATA_DIR, tmp_path)
 
 


### PR DESCRIPTION
Never write into the source data directory.
The data directory is now copied into a temporary directory to allow test execution also when pooch is installed into a read-only location.

Closes #248


**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
