### PR TITLE
Add file_hash back to pooch.utils with a warning

### DIFF
--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -50,7 +50,7 @@ def file_hash(*args, **kwargs):
     top-level namespace (`from pooch import file_hash`) instead, which is fully
     backwards compatible with pooch >= 0.1.
     """
-    warnings.warn(message, FutureWarning)
+    warnings.warn(message, DeprecationWarning)
     return new_file_hash(*args, **kwargs)
 
 

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -14,6 +14,7 @@ import hashlib
 from pathlib import Path
 from urllib.parse import urlsplit
 from contextlib import contextmanager
+import warnings
 
 import appdirs
 from packaging.version import Version
@@ -21,6 +22,36 @@ from packaging.version import Version
 
 LOGGER = logging.Logger("pooch")
 LOGGER.addHandler(logging.StreamHandler())
+
+
+def file_hash(*args, **kwargs):
+    """
+    WARNING: Importing this function from pooch.utils is DEPRECATED.
+    Please import from the top-level namespace (`from pooch import file_hash`)
+    instead, which is fully backwards compatible with pooch >= 0.1.
+
+    Examples
+    --------
+
+    >>> fname = "test-file-for-hash.txt"
+    >>> with open(fname, "w") as f:
+    ...     __ = f.write("content of the file")
+    >>> print(file_hash(fname))
+    0fc74468e6a9a829f103d069aeb2bb4f8646bad58bf146bb0e3379b759ec4a00
+    >>> import os
+    >>> os.remove(fname)
+
+    """
+    # pylint: disable=import-outside-toplevel
+    from .hashes import file_hash as new_file_hash
+
+    message = """
+    Importing file_hash from pooch.utils is DEPRECATED. Please import from the
+    top-level namespace (`from pooch import file_hash`) instead, which is fully
+    backwards compatible with pooch >= 0.1.
+    """
+    warnings.warn(message, FutureWarning)
+    return new_file_hash(*args, **kwargs)
 
 
 def get_logger():


### PR DESCRIPTION
Moving this function to pooch.hashes caused crashes downstream. To prevent these crashes, add a wrapper back to utils that issues a warning to import from the top-level namespace instead.

Fixes #252 

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
