### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: [3.6, 3.9]
+        python: ["3.6", "3.9", "3.10-dev"]
         # If "optional", will install non-required dependencies in the build
         # environment. Otherwise, only required dependencies are installed.
         dependencies: ["", optional]

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
     f"License :: OSI Approved :: {LICENSE}",
 ]


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Python 3.10.0 final is due for release in October:

* https://www.python.org/dev/peps/pep-0619/

The first release candidate is now out and the Python release team has issued a call to action for community members:

> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.10 compatibilities during this phase. As always, report any issues to the Python bug tracker.

https://discuss.python.org/t/python-3-10-0rc1-is-now-available/9982?u=hugovk

---

Turned out to be useful to try this now, a test dependency didn't yet support 3.10, so we've now fixed that and as of half an hour ago they released a new version with support: https://github.com/oz123/pytest-localftpserver/pull/146 🚀 

So now Pooch can also test and support Python 3.10. 🚀 


---

**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [n/a] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [n/a] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [n/a] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
