### PR TITLE
Remove old testing checks if running on TravisCI

### DIFF
--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -34,8 +34,6 @@ from .utils import (
     mirror_directory,
 )
 
-# FTP doesn't work on Travis CI so need to be able to skip tests there
-ON_TRAVIS = bool(os.environ.get("TRAVIS", None))
 DATA_DIR = str(Path(__file__).parent / "data")
 REGISTRY = pooch_test_registry()
 BASEURL = pooch_test_url()
@@ -430,9 +428,7 @@ def test_check_availability():
     assert not pup.is_available("not-a-real-data-file.txt")
 
 
-# https://blog.travis-ci.com/2018-07-23-the-tale-of-ftp-at-travis-ci
 @pytest.mark.network
-@pytest.mark.skipif(ON_TRAVIS, reason="FTP is not allowed on Travis CI")
 def test_check_availability_on_ftp():
     "Should correctly check availability of existing and non existing files"
     # Check available remote file on FTP server

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -43,8 +43,6 @@ from .utils import (
 )
 
 
-# FTP doesn't work on Travis CI so need to be able to skip tests there
-ON_TRAVIS = bool(os.environ.get("TRAVIS", None))
 BASEURL = pooch_test_url()
 FIGSHAREURL = pooch_test_figshare_url()
 ZENODOURL = pooch_test_zenodo_url()
@@ -116,7 +114,6 @@ def test_ftp_downloader(ftpserver):
 
 @pytest.mark.network
 @pytest.mark.skipif(paramiko is None, reason="requires paramiko to run SFTP")
-@pytest.mark.skipif(ON_TRAVIS, reason="SFTP is not allowed on Travis CI")
 def test_sftp_downloader():
     "Test sftp downloader"
     with TemporaryDirectory() as local_store:
@@ -129,7 +126,6 @@ def test_sftp_downloader():
 
 @pytest.mark.network
 @pytest.mark.skipif(paramiko is None, reason="requires paramiko to run SFTP")
-@pytest.mark.skipif(ON_TRAVIS, reason="SFTP is not allowed on Travis CI")
 def test_sftp_downloader_fail_if_file_object():
     "Downloader should fail when a file object rather than string is passed"
     with TemporaryDirectory() as local_store:
@@ -215,7 +211,6 @@ def test_downloader_progressbar_ftp(capsys, ftpserver):
 @pytest.mark.network
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")
 @pytest.mark.skipif(paramiko is None, reason="requires paramiko")
-@pytest.mark.skipif(ON_TRAVIS, reason="SFTP is not allowed on Travis CI")
 def test_downloader_progressbar_sftp(capsys):
     "Setup an SFTP downloader function that prints a progress bar for fetch"
     downloader = SFTPDownloader(progressbar=True, username="demo", password="password")


### PR DESCRIPTION
We haven't been using the service in quite some time and won't be doing
so again in the future. Removes the checks to see if tests are running
on Travis to skip FTP tests.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
