### PR TITLE
Fix bug when unpacking a subfolder from an archive

### DIFF
--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -120,9 +120,10 @@ def test_extractprocessor_fails():
     [
         ("store", None),  # all files in an archive
         ("tiny-data", ["tiny-data.txt"]),  # 1 compressed file
-        ("store", ["store/subdir/tiny-data.txt"]),  # 1 file nested in archive
+        ("store", ["store/subdir/tiny-data.txt"]),  # 1 file in a subdir
+        ("store", ["store/subdir"]),  # whole subdir
     ],
-    ids=["all_files", "single_file", "subdir_file"],
+    ids=["all_files", "single_file", "subdir_file", "subdir_whole"],
 )
 @pytest.mark.parametrize(
     "processor_class,extension",
@@ -136,6 +137,8 @@ def test_unpacking(processor_class, extension, target_path, archive, members):
         target_path = archive + extension + processor.suffix
     with TemporaryDirectory() as local_store:
         path = Path(local_store)
+        # Generate the appropriate expected paths and log message depending on
+        # the parameters for the test
         if archive == "tiny-data":
             true_paths = {str(path / target_path / "tiny-data.txt")}
             log_line = "Extracting 'tiny-data.txt'"


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Our unpacking processors (`Untar` and `Unzip`) aren't handling `members` that are a whole subfolder correctly. The elements of `members` are being treated as files regardless of what they are. Add a test for use case (no change to our test data required) and refactor the unpacking test to make it easier to extend in the future.

Fixes #264 






**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
