### PR TITLE
Fix typo on SFTP in doc/about.rst

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -19,7 +19,7 @@ Use cases
       once).
     * Make sure everyone running the code has the same version of the data
       files by verifying cryptographic hashes.
-    * Multiple download protocols HTTP/FTP/SFT and basic authentication.
+    * Multiple download protocols HTTP/FTP/SFTP and basic authentication.
     * Download from Digital Object Identifiers (DOIs) issued by repositories
       like figshare and Zenodo.
     * Built-in utilities to unzip/decompress files upon download
@@ -38,7 +38,7 @@ Use cases
     * Verification of download integrity through cryptographic hashes.
     * Extensible design: plug in custom download and post-processing functions.
     * Built-in utilities to unzip/decompress files upon download
-    * Multiple download protocols HTTP/FTP/SFT and basic authentication.
+    * Multiple download protocols HTTP/FTP/SFTP and basic authentication.
     * User control of data cache location through environment variables.
 
     **Start here:** :ref:`intermediate`


### PR DESCRIPTION
Fix typo on the SFTP protocol when listing the available protocols in the documentation.



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
