### PR TITLE
Run CI tests on 3.10 instead of 3.10-dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.6", "3.9", "3.10-dev"]
+        python: ["3.6", "3.10"]
         # If "optional", will install non-required dependencies in the build
         # environment. Otherwise, only required dependencies are installed.
         dependencies: ["", optional]

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - python==3.8
+    - python==3.9
     - pip
     - requests
     - packaging
@@ -17,7 +17,8 @@ dependencies:
     - coverage
     - black>=20.8b1
     - flake8
-    - pylint==2.4.*
     - sphinx==3.5.*
     - sphinx-book-theme==0.0.41
     - sphinx-panels==0.5.*
+    - pip:
+      - pylint==2.4.*


### PR DESCRIPTION
Remove 3.9 from the test matrix and only run on 3.6 and 3.10 now.
Development environment and docs still need to be 3.9 because some
sphinx dependencies are still not available for 3.10.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
