### PR TITLE
Allow access to progressbar kwarg from pooch.retrieve & fetch

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,6 +4,7 @@ The following people have made contributions to the project (in alphabetical
 order by last name) and are considered "The Pooch Developers":
 
 * [Anderson Banihirwe](https://github.com/andersy005) - The US National Center for Atmospheric Research, USA (ORCID: [0000-0001-6583-571X](https://orcid.org/0000-0001-6583-571X))
+* [Genevieve Buckley](https://github.com/GenevieveBuckley/) - Monash University, Australia - (ORCID: [0000-0003-2763-492X](https://orcid.org/0000-0003-2763-492X))
 * [Luke Gregor](https://github.com/luke-gregor) - Environmental Physics, ETH Zurich, Zurich, Switzerland (ORCID: [0000-0001-6071-1857](https://orcid.org/0000-0001-6071-1857))
 * [Mathias Hauser](https://github.com/mathause) - Institute for Atmospheric and Climate Science, ETH Zurich, Zurich, Switzerland (ORCID: [0000-0002-0057-4878](https://orcid.org/0000-0002-0057-4878))
 * [Mark Harfouche](https://github.com/hmaarrfk) - Ramona Optics Inc. - [0000-0002-4657-4603](https://orcid.org/0000-0002-4657-4603)

--- a/doc/progressbars.rst
+++ b/doc/progressbars.rst
@@ -8,9 +8,30 @@ Printing progress bars
 Using ``tqdm`` progress bars
 ----------------------------
 
-The :class:`~pooch.HTTPDownloader` can use
+Pooch uses
 `tqdm <https://github.com/tqdm/tqdm>`__ to print a download progress bar.
-This is turned off by default but can be enabled using:
+This is turned off by default but can be enabled using ``progressbar=True``.
+
+.. code:: python
+
+    # Assuming you want to use the pooch retrieve function
+    fname = retrieve(
+        url="https://some-data-server.org/a-data-file.nc",
+        known_hash="md5:70e2afd3fd7e336ae478b1e740a5f08e",
+        progressbar=True
+    )
+
+
+The resulting progress bar will be printed to the standard error stream
+(STDERR) and should look something like this:
+
+.. code::
+
+    100%|█████████████████████████████████████████| 336/336 [...]
+
+
+Alternatively, assuming you have a ``pooch.Pooch`` instance setup,
+you can turn on progress bars like this:
 
 .. code:: python
 
@@ -21,15 +42,14 @@ This is turned off by default but can be enabled using:
 
     fname = POOCH.fetch(
         "large-data-file.h5",
-        downloader=pooch.HTTPDownloader(progressbar=True),
+        progressbar=True
     )
 
-The resulting progress bar will be printed to the standard error stream
-(STDERR) and should look something like this:
-
-.. code::
-
-    100%|█████████████████████████████████████████| 336/336 [...]
+    # Or, you can pass `progressbar` directly into the downloader
+    fname = POOCH.fetch(
+        "large-data-file.h5",
+        downloader=pooch.HTTPDownloader(progressbar=True),
+    )
 
 .. note::
 

--- a/doc/progressbars.rst
+++ b/doc/progressbars.rst
@@ -18,7 +18,7 @@ This is turned off by default but can be enabled using ``progressbar=True``.
     fname = retrieve(
         url="https://some-data-server.org/a-data-file.nc",
         known_hash="md5:70e2afd3fd7e336ae478b1e740a5f08e",
-        progressbar=True
+        progressbar=True,
     )
 
 
@@ -42,7 +42,7 @@ you can turn on progress bars like this:
 
     fname = POOCH.fetch(
         "large-data-file.h5",
-        progressbar=True
+        progressbar=True,
     )
 
     # Or, you can pass `progressbar` directly into the downloader

--- a/doc/progressbars.rst
+++ b/doc/progressbars.rst
@@ -8,13 +8,12 @@ Printing progress bars
 Using ``tqdm`` progress bars
 ----------------------------
 
-Pooch uses
-`tqdm <https://github.com/tqdm/tqdm>`__ to print a download progress bar.
-This is turned off by default but can be enabled using ``progressbar=True``.
+Pooch uses `tqdm <https://github.com/tqdm/tqdm>`__ to print a download progress
+bar. This is turned off by default but can be enabled using
+``progressbar=True`` in :func:`pooch.retrieve`:
 
 .. code:: python
 
-    # Assuming you want to use the pooch retrieve function
     fname = retrieve(
         url="https://some-data-server.org/a-data-file.nc",
         known_hash="md5:70e2afd3fd7e336ae478b1e740a5f08e",
@@ -30,12 +29,10 @@ The resulting progress bar will be printed to the standard error stream
     100%|█████████████████████████████████████████| 336/336 [...]
 
 
-Alternatively, assuming you have a ``pooch.Pooch`` instance setup,
-you can turn on progress bars like this:
+You can also do the same with :meth:`pooch.Pooch.fetch`:
 
 .. code:: python
 
-    # Assuming you have a pooch.Pooch instance setup
     POOCH = pooch.create(
         ...
     )
@@ -45,9 +42,21 @@ you can turn on progress bars like this:
         progressbar=True,
     )
 
-    # Or, you can pass `progressbar` directly into the downloader
+Alternatively, you can pass ``progressbar=True`` directly into one of our
+:ref:`downloaders <downloaders>`:
+
+.. code:: python
+
+    # Using fetch
     fname = POOCH.fetch(
         "large-data-file.h5",
+        downloader=pooch.HTTPDownloader(progressbar=True),
+    )
+
+    # Using retrieve
+    fname = retrieve(
+        url="https://some-data-server.org/a-data-file.nc",
+        known_hash="md5:70e2afd3fd7e336ae478b1e740a5f08e",
         downloader=pooch.HTTPDownloader(progressbar=True),
     )
 

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -471,7 +471,7 @@ class Pooch:
         "List of file names on the registry"
         return list(self.registry)
 
-    def fetch(self, fname, processor=None, downloader=None):
+    def fetch(self, fname, processor=None, downloader=None, progressbar=False):
         """
         Get the absolute path to a file in the local storage.
 
@@ -509,6 +509,9 @@ class Pooch:
             If not None, then a function (or callable object) that will be
             called to download a given URL to a provided local file name. See
             :ref:`downloaders` for details.
+        progressbar : False, optional
+            If True and the downloader keyword argument is None, a progress bar is displayed.
+            The progress bar will be printed to the standard error stream (STDERR).
 
         Returns
         -------
@@ -537,7 +540,7 @@ class Pooch:
             )
 
             if downloader is None:
-                downloader = choose_downloader(url)
+                downloader = choose_downloader(url, progressbar=progressbar)
 
             stream_download(
                 url,

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -31,7 +31,15 @@ from .utils import (
 from .downloaders import choose_downloader
 
 
-def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=None, progressbar=False):
+def retrieve(
+    url,
+    known_hash,
+    fname=None,
+    path=None,
+    processor=None,
+    downloader=None,
+    progressbar=False,
+):
     """
     Download and cache a single file locally.
 
@@ -510,8 +518,9 @@ class Pooch:
             called to download a given URL to a provided local file name. See
             :ref:`downloaders` for details.
         progressbar : False, optional
-            If True and the downloader keyword argument is None, a progress bar is displayed.
-            The progress bar will be printed to the standard error stream (STDERR).
+            If True and the downloader keyword argument is None, then
+            a progress bar is displayed.
+            The progress bar will be printed to the standard error stream.
 
         Returns
         -------

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -105,9 +105,11 @@ def retrieve(
         If not None, then a function (or callable object) that will be called
         to download a given URL to a provided local file name. See
         :ref:`downloaders` for details.
-    progressbar : False, optional
-        If True, pooch will display a progress bar tracking the data download.
-        The progress bar will be printed to the standard error stream (STDERR).
+    progressbar : bool or an arbitrary progress bar object
+        If True, will print a progress bar of the download to standard error
+        (stderr). Requires `tqdm <https://github.com/tqdm/tqdm>`__ to be
+        installed. Alternatively, an arbitrary progress bar object can be
+        passed. See :ref:`custom-progressbar` for details.
 
     Returns
     -------
@@ -517,10 +519,11 @@ class Pooch:
             If not None, then a function (or callable object) that will be
             called to download a given URL to a provided local file name. See
             :ref:`downloaders` for details.
-        progressbar : False, optional
-            If True and the downloader keyword argument is None, then
-            a progress bar is displayed.
-            The progress bar will be printed to the standard error stream.
+        progressbar : bool or an arbitrary progress bar object
+            If True, will print a progress bar of the download to standard
+            error (stderr). Requires `tqdm <https://github.com/tqdm/tqdm>`__ to
+            be installed. Alternatively, an arbitrary progress bar object can
+            be passed. See :ref:`custom-progressbar` for details.
 
         Returns
         -------

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -31,7 +31,7 @@ from .utils import (
 from .downloaders import choose_downloader
 
 
-def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=None):
+def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=None, progressbar=False):
     """
     Download and cache a single file locally.
 
@@ -97,6 +97,9 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
         If not None, then a function (or callable object) that will be called
         to download a given URL to a provided local file name. See
         :ref:`downloaders` for details.
+    progressbar : False, optional
+        If True, pooch will display a progress bar tracking the data download.
+        The progress bar will be printed to the standard error stream (STDERR).
 
     Returns
     -------
@@ -222,7 +225,7 @@ def retrieve(url, known_hash, fname=None, path=None, processor=None, downloader=
         )
 
         if downloader is None:
-            downloader = choose_downloader(url)
+            downloader = choose_downloader(url, progressbar=progressbar)
 
         stream_download(url, full_path, known_hash, downloader, pooch=None)
 

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -33,9 +33,11 @@ def choose_downloader(url, progressbar=False):
     ----------
     url : str
         A URL (including protocol).
-    progressbar : False, optional
-        If True, pooch will display a progress bar tracking the data download.
-        The progress bar will be printed to the standard error stream (STDERR).
+    progressbar : bool or an arbitrary progress bar object
+        If True, will print a progress bar of the download to standard error
+        (stderr). Requires `tqdm <https://github.com/tqdm/tqdm>`__ to be
+        installed. Alternatively, an arbitrary progress bar object can be
+        passed. See :ref:`custom-progressbar` for details.
 
     Returns
     -------

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -25,7 +25,7 @@ except ImportError:
     paramiko = None
 
 
-def choose_downloader(url):
+def choose_downloader(url, progressbar=False):
     """
     Choose the appropriate downloader for the given URL based on the protocol.
 
@@ -33,6 +33,9 @@ def choose_downloader(url):
     ----------
     url : str
         A URL (including protocol).
+    progressbar : False, optional
+        If True, pooch will display a progress bar tracking the data download.
+        The progress bar will be printed to the standard error stream (STDERR).
 
     Returns
     -------
@@ -71,7 +74,7 @@ def choose_downloader(url):
             f"Unrecognized URL protocol '{parsed_url['protocol']}' in '{url}'. "
             f"Must be one of {known_downloaders.keys()}."
         )
-    downloader = known_downloaders[parsed_url["protocol"]]()
+    downloader = known_downloaders[parsed_url["protocol"]](progressbar=progressbar)
     return downloader
 
 

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -54,6 +54,7 @@ ZENODOURL = pooch_test_zenodo_url()
     "sftp://test.rebex.net/pub/example/pocketftp.png",  # SFTPDownloader
 ])
 def test_progressbar_kwarg_passed(url):
+    """The progressbar keyword argument must pass through choose_downloader"""
     d = choose_downloader(url, progressbar=True)
     assert d.progressbar is True
 

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -48,6 +48,7 @@ FIGSHAREURL = pooch_test_figshare_url()
 ZENODOURL = pooch_test_zenodo_url()
 
 
+@pytest.mark.skipif(tqdm is None, reason="requires tqdm")
 @pytest.mark.parametrize(
     "url",
     [

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -48,6 +48,16 @@ FIGSHAREURL = pooch_test_figshare_url()
 ZENODOURL = pooch_test_zenodo_url()
 
 
+@pytest.mark.parametrize("url", [
+    BASEURL + "tiny-data.txt",  # HTTPDownloader
+    FIGSHAREURL,  # DOIDownloader
+    "sftp://test.rebex.net/pub/example/pocketftp.png",  # SFTPDownloader
+])
+def test_progressbar_kwarg_passed(url):
+    d = choose_downloader(url, progressbar=True)
+    assert d.progressbar is True
+
+
 def test_unsupported_protocol():
     "Should raise ValueError when protocol is not supported"
     with pytest.raises(ValueError):

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -59,8 +59,8 @@ ZENODOURL = pooch_test_zenodo_url()
 )
 def test_progressbar_kwarg_passed(url):
     """The progressbar keyword argument must pass through choose_downloader"""
-    d = choose_downloader(url, progressbar=True)
-    assert d.progressbar is True
+    downloader = choose_downloader(url, progressbar=True)
+    assert downloader.progressbar is True
 
 
 def test_unsupported_protocol():

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -48,11 +48,14 @@ FIGSHAREURL = pooch_test_figshare_url()
 ZENODOURL = pooch_test_zenodo_url()
 
 
-@pytest.mark.parametrize("url", [
-    BASEURL + "tiny-data.txt",  # HTTPDownloader
-    FIGSHAREURL,  # DOIDownloader
-    "sftp://test.rebex.net/pub/example/pocketftp.png",  # SFTPDownloader
-])
+@pytest.mark.parametrize(
+    "url",
+    [
+        BASEURL + "tiny-data.txt",  # HTTPDownloader
+        FIGSHAREURL,  # DOIDownloader
+        "sftp://test.rebex.net/pub/example/pocketftp.png",  # SFTPDownloader
+    ],
+)
 def test_progressbar_kwarg_passed(url):
     """The progressbar keyword argument must pass through choose_downloader"""
     d = choose_downloader(url, progressbar=True)


### PR DESCRIPTION
Closes https://github.com/fatiando/pooch/issues/273

This PR makes the [progress bar](https://github.com/fatiando/pooch/issues/91) keyword arguments accessible from `fetch()` and `retrieve()`. This allows users who don't want to do a lot of setup or configuration, to also get the benefit of progress bars.

**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [x] ~~Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.~~ (Not applicable)
- [x] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [x] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [x] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
