### PR TITLE
Rename "master" to "main" throughout the project

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,14 +6,14 @@
 #
 name: docs
 
-# Only build PRs, the master branch, and releases. Pushes to branches will only
+# Only build PRs, the main branch, and releases. Pushes to branches will only
 # be built when a PR is opened. This avoids duplicated buids in PRs comming
 # from branches in the origin repository (1 for PR and 1 for push).
 on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   release:
     types:
       - published
@@ -168,7 +168,7 @@ jobs:
 
       - name: Push the built HTML to gh-pages
         run: |
-          # Detect if this is a release or from the master branch
+          # Detect if this is a release or from the main branch
           if [[ "${{ github.event_name }}" == "release" ]]; then
               # Get the tag name without the "refs/tags/" part
               version="${GITHUB_REF#refs/*/}"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,11 +6,11 @@
 #
 name: pypi
 
-# Only run for pushes to the master branch and releases.
+# Only run for pushes to the main branch and releases.
 on:
   push:
     branches:
-      - master
+      - main
   release:
     types:
       - published

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,13 +6,13 @@
 #
 name: code-style
 
-# Only build PRs and the master branch. Pushes to branches will only be built
+# Only build PRs and the main branch. Pushes to branches will only be built
 # when a PR is opened.
 on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 ###############################################################################
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,14 @@
 #
 name: test
 
-# Only build PRs, the master branch, and releases. Pushes to branches will only
+# Only build PRs, the main branch, and releases. Pushes to branches will only
 # be built when a PR is opened. This avoids duplicated buids in PRs comming
 # from branches in the origin repository (1 for PR and 1 for push).
 on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   release:
     types:
       - published

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ make lint    # Runs pylint, which is a bit slower
 #### Docstrings
 
 **All docstrings** should follow the
-[numpy style guide](https://github.com/numpy/numpy/blob/main/doc/HOWTO_DOCUMENT.rst.txt).
+[numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard).
 All functions/classes/methods should have docstrings with a full description of all
 arguments and return values.
 
@@ -312,7 +312,7 @@ Some things that will increase the chance that your pull request is accepted qui
   *reason* behind non-obvious things.
 * Include an example of new features in the gallery or tutorials.
 * Follow the [PEP8](http://pep8.org) style guide for code and the
-  [numpy guide](https://github.com/numpy/numpy/blob/main/doc/HOWTO_DOCUMENT.rst.txt)
+  [numpy guide](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)
   for documentation.
 
 Pull requests will automatically have tests run by TravisCI and AppVeyor.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,7 @@ make changes to our codebase.
 Every change made goes through a pull request, even our own, so that our
 [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) services
 have a change to check that the code is up to standards and passes all our tests.
-This way, the *master* branch is always stable.
+This way, the *main* branch is always stable.
 
 General guidelines for pull requests (PRs):
 
@@ -236,7 +236,7 @@ make lint    # Runs pylint, which is a bit slower
 #### Docstrings
 
 **All docstrings** should follow the
-[numpy style guide](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).
+[numpy style guide](https://github.com/numpy/numpy/blob/main/doc/HOWTO_DOCUMENT.rst.txt).
 All functions/classes/methods should have docstrings with a full description of all
 arguments and return values.
 
@@ -312,7 +312,7 @@ Some things that will increase the chance that your pull request is accepted qui
   *reason* behind non-obvious things.
 * Include an example of new features in the gallery or tutorials.
 * Follow the [PEP8](http://pep8.org) style guide for code and the
-  [numpy guide](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt)
+  [numpy guide](https://github.com/numpy/numpy/blob/main/doc/HOWTO_DOCUMENT.rst.txt)
   for documentation.
 
 Pull requests will automatically have tests run by TravisCI and AppVeyor.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -24,9 +24,9 @@ If you want to make a contribution to the project, see the
 
 ## Branches
 
-* *master*: Always tested and ready to become a new version. Don't push directly to this
+* *main*: Always tested and ready to become a new version. Don't push directly to this
   branch. Make a new branch and submit a pull request instead.
-* *gh-pages*: Holds the HTML documentation and is served by Github. Pages for the master
+* *gh-pages*: Holds the HTML documentation and is served by Github. Pages for the main
   branch are in the `dev` folder. Pages for each release are in their own folders.
   **Automatically updated by TravisCI** so you shouldn't have to make commits here.
 
@@ -48,7 +48,7 @@ This means that all commits will be collapsed into one.
 The main advantages of this are:
 
 * Eliminates experimental commits or commits to undo previous changes.
-* Makes sure every commit on master passes the tests and has a defined purpose.
+* Makes sure every commit on main passes the tests and has a defined purpose.
 * The maintainer writes the final commit message, so we can make sure it's good and
   descriptive.
 
@@ -58,7 +58,7 @@ The main advantages of this are:
 We use GitHub Actions continuous integration (CI) services to build and
 test the project on Windows, Linux, and Mac.
 The configuration files for this service are in `.github/workflows`.
-They rely on the `requirements.txt`, `requirements-optional.txt`, etc 
+They rely on the `requirements.txt`, `requirements-optional.txt`, etc
 files to install the required dependencies using conda or pip.
 
 The CI jobs include:
@@ -68,7 +68,7 @@ The CI jobs include:
 * Running Black, flake8, and pylint to check the code for style.
 * Building the documentation to make sure it works.
 * Pushing the built documentation HTML to the `gh-pages` branch.
-* Upload source and wheel distributions to TestPyPI (on master) and PyPI
+* Upload source and wheel distributions to TestPyPI (on main) and PyPI
   (on releases).
 
 This way, most day-to-day maintenance operations are automatic.

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://github.com/fatiando/pooch/raw/master/doc/_static/readme-banner.png
+.. image:: https://github.com/fatiando/pooch/raw/main/doc/_static/readme-banner.png
     :alt: Pooch
 
 `Documentation <https://www.fatiando.org/pooch>`__ |

--- a/README.rst
+++ b/README.rst
@@ -12,10 +12,10 @@ Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 .. image:: https://img.shields.io/conda/vn/conda-forge/pooch.svg?style=flat-square
     :alt: Latest version on conda-forge
     :target: https://github.com/conda-forge/pooch-feedstock
-.. image:: https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Ffatiando%2Fpooch%2Fbadge%3Fref%3Dmaster&style=flat-square&logo=none
+.. image:: https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Ffatiando%2Fpooch%2Fbadge%3Fref%3Dmain&style=flat-square&logo=none
     :alt: GitHub Actions workflow status
     :target: https://github.com/fatiando/pooch/actions
-.. image:: https://img.shields.io/codecov/c/github/fatiando/pooch/master.svg?style=flat-square
+.. image:: https://img.shields.io/codecov/c/github/fatiando/pooch/main.svg?style=flat-square
     :alt: Test coverage status
     :target: https://codecov.io/gh/fatiando/pooch
 .. image:: https://img.shields.io/pypi/pyversions/pooch.svg?style=flat-square
@@ -106,7 +106,7 @@ For **package developers** including sample data in their projects:
         version=version,
         # If a version as a "+XX.XXXXX" suffix, we'll assume that this is a dev
         # version and replace the version with this string.
-        version_dev="master",
+        version_dev="main",
         # An environment variable that overwrites the path.
         env="MYPACKAGE_DATA_DIR",
         # The cache file registry. A dictionary with all files managed by this
@@ -167,11 +167,11 @@ Citing Pooch
 ------------
 
 This is research software **made by scientists** (see
-`AUTHORS.md <https://github.com/fatiando/pooch/blob/master/AUTHORS.md>`__). Citations
+`AUTHORS.md <https://github.com/fatiando/pooch/blob/main/AUTHORS.md>`__). Citations
 help us justify the effort that goes into building and maintaining this project. If you
 used Pooch for your research, please consider citing us.
 
-See our `CITATION.rst file <https://github.com/fatiando/pooch/blob/master/CITATION.rst>`__
+See our `CITATION.rst file <https://github.com/fatiando/pooch/blob/main/CITATION.rst>`__
 to find out more.
 
 
@@ -182,14 +182,14 @@ Code of conduct
 +++++++++++++++
 
 Please note that this project is released with a
-`Contributor Code of Conduct <https://github.com/fatiando/pooch/blob/master/CODE_OF_CONDUCT.md>`__.
+`Code of Conduct <https://github.com/fatiando/community/blob/main/CODE_OF_CONDUCT.md>`__.
 By participating in this project you agree to abide by its terms.
 
 Contributing Guidelines
 +++++++++++++++++++++++
 
 Please read our
-`Contributing Guide <https://github.com/fatiando/pooch/blob/master/CONTRIBUTING.md>`__
+`Contributing Guide <https://github.com/fatiando/pooch/blob/main/CONTRIBUTING.md>`__
 to see how you can help and give feedback.
 
 Imposter syndrome disclaimer
@@ -224,5 +224,5 @@ License
 -------
 
 This is free software: you can redistribute it and/or modify it under the terms
-of the `BSD 3-clause License <https://github.com/fatiando/pooch/blob/master/LICENSE.txt>`__.
+of the `BSD 3-clause License <https://github.com/fatiando/pooch/blob/main/LICENSE.txt>`__.
 A copy of this license is provided with distributions of the software.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -90,7 +90,7 @@ html_show_copyright = True
 html_theme = "sphinx_book_theme"
 html_theme_options = {
     "repository_url": f"https://github.com/fatiando/{project.lower()}",
-    "repository_branch": "master",
+    "repository_branch": "main",
     "path_to_docs": "doc",
     "launch_buttons": {
         "binderhub_url": "https://mybinder.org",

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -120,9 +120,9 @@ Table of contents
 .. toctree::
     :caption: Community
 
-    Join the community <http://contact.fatiando.org>
-    Code of Conduct <https://github.com/fatiando/pooch/blob/master/CODE_OF_CONDUCT.md>
-    How to contribute <https://github.com/fatiando/pooch/blob/master/CONTRIBUTING.md>
+    Join the community <https://www.fatiando.org/contact/>
+    Code of Conduct <https://github.com/fatiando/community/blob/main/CODE_OF_CONDUCT.md>
+    How to contribute <https://github.com/fatiando/pooch/blob/main/CONTRIBUTING.md>
     Source code on GitHub <https://github.com/fatiando/pooch>
-    Authors <https://github.com/fatiando/pooch/blob/master/AUTHORS.md>
+    Authors <https://github.com/fatiando/pooch/blob/main/AUTHORS.md>
     Fatiando a Terra <https://www.fatiando.org>

--- a/doc/multiple-urls.rst
+++ b/doc/multiple-urls.rst
@@ -18,7 +18,7 @@ For example, say we have a ``citadel.csv`` file that we want to download from
         path=pooch.os_cache("plumbus"),
         base_url="https://github.com/rick/plumbus/raw/{version}/data/",
         version=version,
-        version_dev="master",
+        version_dev="main",
         registry={
             "c137.csv": "19uheidhlkjdwhoiwuhc0uhcwljchw9ochwochw89dcgw9dcgwc",
             "cronen.csv": "1upodh2ioduhw9celdjhlfvhksgdwikdgcowjhcwoduchowjg8w",
@@ -73,7 +73,7 @@ In fact, the module code doesn't change at all:
         path=pooch.os_cache("plumbus"),
         base_url="https://github.com/rick/plumbus/raw/{version}/data/",
         version=version,
-        version_dev="master",
+        version_dev="main",
         registry=None,
     )
     # If custom URLs are present in the registry file, they will be set

--- a/doc/protocols.rst
+++ b/doc/protocols.rst
@@ -25,7 +25,7 @@ following setup:
         # Use an FTP server instead of HTTP. The rest is all the same.
         base_url="ftp://garage-basement.org/{version}/",
         version=version,
-        version_dev="master",
+        version_dev="main",
         registry={
             "c137.csv": "19uheidhlkjdwhoiwuhc0uhcwljchw9ochwochw89dcgw9dcgwc",
             "cronen.csv": "1upodh2ioduhw9celdjhlfvhksgdwikdgcowjhcwoduchowjg8w",

--- a/doc/user-defined-cache.rst
+++ b/doc/user-defined-cache.rst
@@ -17,7 +17,7 @@ using an environment variable:
         path=pooch.os_cache("plumbus"),
         base_url="https://github.com/rick/plumbus/raw/{version}/data/",
         version=version,
-        version_dev="master",
+        version_dev="main",
         registry={
             "c137.csv": "19uheidhlkjdwhoiwuhc0uhcwljchw9ochwochw89dcgw9dcgwc",
             "cronen.csv": "1upodh2ioduhw9celdjhlfvhksgdwikdgcowjhcwoduchowjg8w",

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -126,7 +126,7 @@ def retrieve(
     >>> from pooch import __version__, check_version, retrieve
     >>> # Make a URL for the version of pooch we have installed
     >>> url = "https://github.com/fatiando/pooch/raw/{}/data/tiny-data.txt"
-    >>> url = url.format(check_version(__version__))
+    >>> url = url.format(check_version(__version__, fallback="main"))
     >>> # Download the file and save it locally. Will check the MD5 checksum of
     >>> # the downloaded file against the given value to make sure it's the
     >>> # right file. You can use other hashes by specifying different
@@ -154,7 +154,7 @@ def retrieve(
     >>> # URLs to a gzip compressed version of the data file.
     >>> url = ("https://github.com/fatiando/pooch/raw/{}/"
     ...        + "pooch/tests/data/tiny-data.txt.gz")
-    >>> url = url.format(check_version(__version__))
+    >>> url = url.format(check_version(__version__, fallback="main"))
     >>> # By default, you would have to decompress the file yourself
     >>> fname = retrieve(
     ...     url,
@@ -186,7 +186,7 @@ def retrieve(
     >>> # URLs to a zip archive with a single data file.
     >>> url = ("https://github.com/fatiando/pooch/raw/{}/"
     ...        + "pooch/tests/data/tiny-data.zip")
-    >>> url = url.format(check_version(__version__))
+    >>> url = url.format(check_version(__version__, fallback="main"))
     >>> # By default, you would get the path to the archive
     >>> fname = retrieve(
     ...     url,

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -113,7 +113,7 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
     >>> import os
     >>> from pooch import __version__, check_version
     >>> url = "https://github.com/fatiando/pooch/raw/{}/data/tiny-data.txt"
-    >>> url = url.format(check_version(__version__))
+    >>> url = url.format(check_version(__version__, fallback="main"))
     >>> downloader = HTTPDownloader()
     >>> # Not using with Pooch.fetch so no need to pass an instance of Pooch
     >>> downloader(url=url, output_file="tiny-data.txt", pooch=None)

--- a/pooch/tests/test_integration.py
+++ b/pooch/tests/test_integration.py
@@ -29,7 +29,7 @@ def test_create_and_fetch():
         path=path,
         base_url="https://github.com/fatiando/pooch/raw/{version}/data/",
         version=full_version,
-        version_dev="master",
+        version_dev="main",
         env="POOCH_DATA_DIR",
     )
     # Make sure the storage isn't created until a download is required

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -48,8 +48,8 @@ def pooch_test_url():
     """
     Get the base URL for the test data used in Pooch itself.
 
-    The URL is a github raw link to the ``pooch/tests/data`` directory from the
-    `Github repository <https://github.com/fatiando/pooch>`__. It matches the
+    The URL is a GitHub raw link to the ``pooch/tests/data`` directory from the
+    `GitHub repository <https://github.com/fatiando/pooch>`__. It matches the
     pooch version specified in ``pooch.version.full_version``.
 
     Returns
@@ -59,7 +59,7 @@ def pooch_test_url():
 
     """
     url = "https://github.com/fatiando/pooch/raw/{version}/pooch/tests/data/".format(
-        version=check_version(full_version)
+        version=check_version(full_version, fallback="main")
     )
     return url
 


### PR DESCRIPTION
Update the default branch name is CI and testing. The default in the
`Pooch` class remains "master" for backwards compatibility and won't be
changed until v2.0. Updated the links to our guides as well.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Fixes #276 



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
