### PR TITLE
Remove trailing slash from GitHub handle in AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,7 +4,7 @@ The following people have made contributions to the project (in alphabetical
 order by last name) and are considered "The Pooch Developers":
 
 * [Anderson Banihirwe](https://github.com/andersy005) - The US National Center for Atmospheric Research, USA (ORCID: [0000-0001-6583-571X](https://orcid.org/0000-0001-6583-571X))
-* [Genevieve Buckley](https://github.com/GenevieveBuckley/) - Monash University, Australia - (ORCID: [0000-0003-2763-492X](https://orcid.org/0000-0003-2763-492X))
+* [Genevieve Buckley](https://github.com/GenevieveBuckley) - Monash University, Australia - (ORCID: [0000-0003-2763-492X](https://orcid.org/0000-0003-2763-492X))
 * [Luke Gregor](https://github.com/luke-gregor) - Environmental Physics, ETH Zurich, Zurich, Switzerland (ORCID: [0000-0001-6071-1857](https://orcid.org/0000-0001-6071-1857))
 * [Mathias Hauser](https://github.com/mathause) - Institute for Atmospheric and Climate Science, ETH Zurich, Zurich, Switzerland (ORCID: [0000-0002-0057-4878](https://orcid.org/0000-0002-0057-4878))
 * [Mark Harfouche](https://github.com/hmaarrfk) - Ramona Optics Inc. - [0000-0002-4657-4603](https://orcid.org/0000-0002-4657-4603)


### PR DESCRIPTION
Remove a trailing slash from Genevieve Buckley's GitHub handle in `AUTHORS.md` so the [fatiando website](https://www.github.com/fatiando/website) can render her handle and her picture correctly.

**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
