### PR TITLE
Update the contact link to fatiando.org/contact

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,6 @@
 
 `Documentation <https://www.fatiando.org/pooch>`__ |
 `Documentation (dev version) <https://www.fatiando.org/pooch/dev>`__ |
-`Contact <http://contact.fatiando.org>`__ |
 Part of the `Fatiando a Terra <https://www.fatiando.org>`__ project
 
 .. image:: https://img.shields.io/pypi/v/pooch.svg?style=flat-square
@@ -155,12 +154,8 @@ Projects using Pooch
 Contacting Us
 -------------
 
-* Most discussion happens `on Github <https://github.com/fatiando/pooch>`__.
-  Feel free to `open an issue
-  <https://github.com/fatiando/pooch/issues/new>`__ or comment
-  on any open issue or pull request.
-* We have `chat room on Slack <http://contact.fatiando.org>`__ where you can
-  ask questions and leave comments.
+Find out more about how to reach us at
+`fatiando.org/contact <https://www.fatiando.org/contact/>`__
 
 
 Citing Pooch

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,11 +39,11 @@
     **Need help?**
     ^^^^^^^^^^^^^^
 
-    Ask on our chat room
+    Ask on our community channels
 
-    .. link-button:: http://contact.fatiando.org
+    .. link-button:: https://www.fatiando.org/contact
         :type: url
-        :text: Join our Slack
+        :text: Join the conversation
         :classes: btn-outline-primary btn-block stretched-link
 
     ---


### PR DESCRIPTION
There were some uses of the deprecated subdomain contact.fatiando.org
link in the README and documentation.

Related to fatiando/community#43

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
