### PR TITLE
Tell users to import from the top-level namespace

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -3,57 +3,64 @@
 List of functions and classes (API)
 ===================================
 
-.. automodule:: pooch
+.. note::
 
-.. currentmodule:: pooch
+    **All functions and classes should be accessed from the** :mod:`pooch`
+    **top-level namespace.**
+
+    Modules inside of the :mod:`pooch` package are meant mostly for internal
+    organization. Please **avoid importing** directly from submodules since
+    functions/classes may be moved around.
+
+.. automodule:: pooch
 
 Core
 ----
 
 .. autosummary::
-   :toctree: generated/
+    :toctree: generated/
 
-    create
-    Pooch
-    retrieve
+    pooch.create
+    pooch.Pooch
+    pooch.retrieve
 
 Utilities
 ---------
 
 .. autosummary::
-   :toctree: generated/
+    :toctree: generated/
 
-    os_cache
-    make_registry
-    file_hash
-    check_version
-    get_logger
+    pooch.os_cache
+    pooch.make_registry
+    pooch.file_hash
+    pooch.check_version
+    pooch.get_logger
 
 Downloaders
 -----------
 
 .. autosummary::
-   :toctree: generated/
+    :toctree: generated/
 
-   HTTPDownloader
-   FTPDownloader
-   SFTPDownloader
-   DOIDownloader
+    pooch.HTTPDownloader
+    pooch.FTPDownloader
+    pooch.SFTPDownloader
+    pooch.DOIDownloader
 
 Processors
 ----------
 
 .. autosummary::
-   :toctree: generated/
+    :toctree: generated/
 
-   Unzip
-   Untar
-   Decompress
+    pooch.Unzip
+    pooch.Untar
+    pooch.Decompress
 
 Miscellaneous
 -------------
 
 .. autosummary::
-   :toctree: generated/
+    :toctree: generated/
 
-    test
+    pooch.test


### PR DESCRIPTION
Add a note to the API docs instructing users to always import from the `pooch` top-level namespace instead of submodules.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->

Fixes #253 



**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
