### PR TITLE
Add option to disable updates

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -263,6 +263,7 @@ def create(
     registry=None,
     urls=None,
     retry_if_failed=0,
+    allow_updates=True,
 ):
     """
     Create a :class:`~pooch.Pooch` with sensible defaults to fetch data files.
@@ -327,6 +328,11 @@ def create(
         attempted once (``retry_if_failed=0``). Initially, will wait for 1s
         between retries and then increase the wait time by 1s with each retry
         until a maximum of 10s.
+    allow_updates : bool or str
+        Whether existing files in local storage that have a hash mismatch with
+        the registry are allowed to update from the remote URL. If a string,
+        this is the name of an environment variable that should be checked
+        for the value. Defaults to ``True``.
 
     Returns
     -------
@@ -414,6 +420,8 @@ def create(
     # to import at the same time (which would try to create the folder several
     # times at once).
     path = cache_location(path, env, version)
+    if isinstance(allow_updates, str):
+        allow_updates = os.environ.get(allow_updates, "true") != "false"
     pup = Pooch(
         path=path,
         base_url=base_url,
@@ -457,10 +465,22 @@ class Pooch:
         attempted once (``retry_if_failed=0``). Initially, will wait for 1s
         between retries and then increase the wait time by 1s with each retry
         until a maximum of 10s.
+    allow_updates : bool
+        Whether existing files in local storage that have a hash mismatch with
+        the registry are allowed to update from the remote URL. Defaults to
+        ``True``.
 
     """
 
-    def __init__(self, path, base_url, registry=None, urls=None, retry_if_failed=0):
+    def __init__(
+        self,
+        path,
+        base_url,
+        registry=None,
+        urls=None,
+        retry_if_failed=0,
+        allow_updates=True,
+    ):
         self.path = path
         self.base_url = base_url
         if registry is None:
@@ -470,6 +490,7 @@ class Pooch:
             urls = dict()
         self.urls = dict(urls)
         self.retry_if_failed = retry_if_failed
+        self.allow_updates = allow_updates
 
     @property
     def abspath(self):
@@ -541,6 +562,11 @@ class Pooch:
         full_path = self.abspath / fname
         known_hash = self.registry[fname]
         action, verb = download_action(full_path, known_hash)
+
+        if action == "update" and not self.allow_updates:
+            raise ValueError(
+                f"{fname} needs to update {full_path} but updates are disallowed."
+            )
 
         if action in ("download", "update"):
             get_logger().info(

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -328,6 +328,26 @@ def test_pooch_update():
             assert log_file.getvalue() == ""
 
 
+def test_pooch_update_disallowed():
+    "Test that disallowing updates works."
+    with TemporaryDirectory() as local_store:
+        path = Path(local_store)
+        # Create a dummy version of tiny-data.txt that is different from the
+        # one in the remote storage
+        true_path = str(path / "tiny-data.txt")
+        with open(true_path, "w") as fin:
+            fin.write("different data")
+        # Setup a pooch in a temp dir
+        pup = Pooch(
+            path=path,
+            base_url=BASEURL,
+            registry=REGISTRY,
+            allow_updates=False,
+        )
+        with pytest.raises(ValueError):
+            pup.fetch("tiny-data.txt")
+
+
 @pytest.mark.network
 def test_pooch_corrupted(data_dir_mirror):
     "Raise an exception if the file hash doesn't match the registry"


### PR DESCRIPTION
<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->
This gives users the option, when creating a Pooch, to disallow updating local copies of files. The intended use case for this is for development checkouts/CI systems where the local copies are canonical and any need to update likely reflects a problem with the registry (like and out of date hash).

Fixes #290.

**Reminders**:

- [x] Run `make format` and `make check` to make sure the code follows the style guide.
- [x] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [x] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
