### PR TITLE
Pass allow_updates from create to Pooch

### DIFF
--- a/doc/sample-data.rst
+++ b/doc/sample-data.rst
@@ -165,6 +165,39 @@ result in a failed download.
     Requires Pooch >= 1.3.0.
 
 
+Disable file updates for testing
+--------------------------------
+
+Sometimes we can forget to update the hash of a file in the registry when we
+change one of the existing data files.
+If this happens in a pull request or any branch that is not the default, Pooch
+will detect that there is a mismatch and will update the local file by
+re-downloading (usually from the default development branch).
+If your tests don't check the file contents exactly (which is usually not
+practical), you can have tests that pass on development or continuous
+integration and then fail once a pull request is merged.
+
+In these cases, it is better to temporarily disallow file updates so that Pooch
+raises an error when the hash doesn't match (indicating that you forgot to
+update it).
+To do so, use the ``allow_updates`` argument in :func:`pooch.create`.
+Setting this to ``False`` will mean that a hash mismatch between local file and
+the registry always results in an error.
+
+.. tip::
+
+    We **do not recommend setting this permanenetly to** ``False``. Instead,
+    set it to the name of an environment variable that activates this
+    behaviour, like ``pooch.create(...,
+    allow_updates="MYPROJECT_ALLOW_UPDATES")``.
+    Then you can set ``MYPROJECT_ALLOW_UPDATES=false`` on continuous
+    integration or when running your tests locally.
+
+.. note::
+
+    Requires Pooch >= 1.6.0.
+
+
 Where to go from here
 ---------------------
 

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -330,9 +330,11 @@ def create(
         until a maximum of 10s.
     allow_updates : bool or str
         Whether existing files in local storage that have a hash mismatch with
-        the registry are allowed to update from the remote URL. If a string,
-        this is the name of an environment variable that should be checked
-        for the value. Defaults to ``True``.
+        the registry are allowed to update from the remote URL. If a string is
+        passed, we will assume it's the name of an environment variable that
+        will be checked for the true/false value. If ``False``, any mismatch
+        with hashes in the registry will result in an error. Defaults to
+        ``True``.
 
     Returns
     -------
@@ -421,13 +423,14 @@ def create(
     # times at once).
     path = cache_location(path, env, version)
     if isinstance(allow_updates, str):
-        allow_updates = os.environ.get(allow_updates, "true") != "false"
+        allow_updates = os.environ.get(allow_updates, "true").lower() != "false"
     pup = Pooch(
         path=path,
         base_url=base_url,
         registry=registry,
         urls=urls,
         retry_if_failed=retry_if_failed,
+        allow_updates=allow_updates,
     )
     return pup
 
@@ -467,8 +470,9 @@ class Pooch:
         until a maximum of 10s.
     allow_updates : bool
         Whether existing files in local storage that have a hash mismatch with
-        the registry are allowed to update from the remote URL. Defaults to
-        ``True``.
+        the registry are allowed to update from the remote URL. If ``False``,
+        any mismatch with hashes in the registry will result in an error.
+        Defaults to ``True``.
 
     """
 


### PR DESCRIPTION
Was forgetting to pass this along from `create` to `Pooch` so the
environment variable setup was being ignored. Fix the error and add a
test for the environment variable plus some documentation in the
tutorials.

<!--
Please describe changes proposed and WHY you made them. If fixing an issue,
include the text "Fixes #XXX" (replace XXX by the issue number. GitHub will
automatically close it when this gets merged.
-->





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
