### PR TITLE
Allow spaces in filenames in registry files

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,6 +10,7 @@ order by last name) and are considered "The Pooch Developers":
 * [Mark Harfouche](https://github.com/hmaarrfk) - Ramona Optics Inc. - [0000-0002-4657-4603](https://orcid.org/0000-0002-4657-4603)
 * [Danilo Horta](https://github.com/horta) - EMBL-EBI, UK
 * [Hugo van Kemenade](https://github.com/hugovk) - Independent (Non-affiliated) (ORCID: [0000-0001-5715-8632](https://www.orcid.org/0000-0001-5715-8632))
+* [Dominic Kempf](https://github.com/dokempf) - Scientific Software Center, Heidelberg University, Germany (ORCID: [0000-0002-6140-2332](https://www.orcid.org/0000-0002-6140-2332))
 * [Kacper Kowalik](https://github.com/Xarthisius) - National Center for Supercomputing Applications, University of Illinois at Urbana-Champaign, USA (ORCID: [0000-0003-1709-3744](https://www.orcid.org/0000-0003-1709-3744))
 * [John Leeman](https://github.com/jrleeman)
 * [Daniel McCloy](https://github.com/drammock) - University of Washington, USA (ORCID: [0000-0002-7572-3241](https://orcid.org/0000-0002-7572-3241))

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -11,6 +11,7 @@ import os
 import time
 import contextlib
 from pathlib import Path
+import shlex
 import shutil
 import ftplib
 
@@ -656,7 +657,7 @@ class Pooch:
                 if line.startswith("#"):
                     continue
 
-                elements = line.split()
+                elements = shlex.split(line)
                 if not len(elements) in [0, 2, 3]:
                     raise OSError(
                         f"Invalid entry in Pooch registry file '{fname}': "

--- a/pooch/tests/data/registry-spaces.txt
+++ b/pooch/tests/data/registry-spaces.txt
@@ -1,0 +1,2 @@
+"tiny space data.txt" baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d
+tiny\ space\ data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d

--- a/pooch/tests/data/registry-spaces.txt
+++ b/pooch/tests/data/registry-spaces.txt
@@ -1,2 +1,2 @@
-"tiny space data.txt" baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d
-tiny\ space\ data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d
+"file with spaces.txt" baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d
+other\ with\ spaces.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d

--- a/pooch/tests/data/tiny space data.txt
+++ b/pooch/tests/data/tiny space data.txt
@@ -1,2 +1,0 @@
-# A tiny data file for test purposes only
-1  2  3  4  5  6

--- a/pooch/tests/data/tiny space data.txt
+++ b/pooch/tests/data/tiny space data.txt
@@ -1,0 +1,2 @@
+# A tiny data file for test purposes only
+1  2  3  4  5  6

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -457,6 +457,12 @@ def test_pooch_load_registry_invalid_line():
         pup.load_registry(os.path.join(DATA_DIR, "registry-invalid.txt"))
 
 
+def test_pooch_load_registry_with_spaces():
+    pup = Pooch(path="", base_url="")
+    pup.load_registry(os.path.join(DATA_DIR, "registry-spaces.txt"))
+    assert "tiny space data.txt" in pup.registry
+
+
 @pytest.mark.network
 def test_check_availability():
     "Should correctly check availability of existing and non existing files"

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -461,7 +461,8 @@ def test_pooch_load_registry_with_spaces():
     "Should check that spaces in filenames are allowed in registry files"
     pup = Pooch(path="", base_url="")
     pup.load_registry(os.path.join(DATA_DIR, "registry-spaces.txt"))
-    assert "tiny space data.txt" in pup.registry
+    assert "file with spaces.txt" in pup.registry
+    assert "other with spaces.txt" in pup.registry
 
 
 @pytest.mark.network

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -458,6 +458,7 @@ def test_pooch_load_registry_invalid_line():
 
 
 def test_pooch_load_registry_with_spaces():
+    "Should check that spaces in filenames are allowed in registry files"
     pup = Pooch(path="", base_url="")
     pup.load_registry(os.path.join(DATA_DIR, "registry-spaces.txt"))
     assert "tiny space data.txt" in pup.registry


### PR DESCRIPTION
Previously, the tokenization would not allow this. The commit introduces
`shlex.split` as a tokenizer that is aware of quotes and escapes.

This fixes #313 