### PR TITLE
DOC: Add SciPy to Projects using Pooch

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ def fetch_gravity_data():
 
 ## Projects using Pooch
 
+* [SciPy](https://github.com/scipy/scipy)
 * [scikit-image](https://github.com/scikit-image/scikit-image)
 * [MetPy](https://github.com/Unidata/MetPy)
 * [icepack](https://github.com/icepack/icepack)


### PR DESCRIPTION
Hi, we recently ([merged](https://github.com/scipy/scipy/commit/d58e74655e1129d5d18f034b5a0219dba90368d3) just today) added a `datasets` submodule in SciPy which will be released in [SciPy 1.10](https://github.com/scipy/scipy/wiki/%2ARelease-Note-Entries-for-SciPy-1.10.0#scipydatasets-introduction), with Pooch as an optional dependency. I thought it would be nice to include that in Pooch's readme doc.

Ps. Thanks for this great, easy-to-use tool. Quite useful!


