### PR TITLE
Add mne-python to the list of Projects using Pooch

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ def fetch_gravity_data():
 * [Open AR-Sandbox](https://github.com/cgre-aachen/open_AR_Sandbox)
 * [climlab](https://github.com/climlab/climlab)
 * [napari](https://github.com/napari/napari)
+* [mne-python](https://github.com/mne-tools/mne-python)
 
 *If you're using Pooch, send us a pull request adding your project to the list.*
 


### PR DESCRIPTION
This patch adds [mne-python](https://github.com/mne-tools/mne-python) to the list of Projects using Pooch.

https://github.com/mne-tools/mne-python#dependencies

https://github.com/mne-tools/mne-python/blob/v1.0.3/mne/datasets/_fetch.py#L229

**Relevant issues/PRs:**

N/A.
