### PR TITLE
Increment paramiko dependency version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
 progress =
     tqdm>=4.41.0,<5.0.0
 sftp =
-    paramiko>=2.7.0
+    paramiko>=2.11.0
 xxhash =
     xxhash>=1.4.3
 


### PR DESCRIPTION
Recently, the `blowfish` library has been [deprecated](https://docs.informatica.com/master-data-management/multidomain-mdm/10-4/release-guide/part-1--version-10-4/notices--new-features--and-changes--10-4-/notices--10-4-/support-changes/deprecated-support-for-blowfish-encryption.html#:~:text=Effective%20in%20version%2010.4,%20support,the%20installation%20and%20upgrade%20process.), which paramiko imported. Therefore, installing pooch with `paramiko>=2.7.0` will print a deprecation warning.

`paramiko>=2.11` fixes this import and should be backwards compatible.