### PR TITLE
Speed up import type (0.05 s to 0.02 s) by lazy loading requests

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -755,6 +755,7 @@ def stream_download(url, fname, known_hash, downloader, pooch=None, retry_if_fai
     will retry the download the specified number of times in case the failure
     was due to a network error.
     """
+    # Lazy import requests to speed up import time
     import requests.exceptions  # pylint: disable=C0415
 
     # Ensure the parent directory exists in case the file is in a subdirectory.

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -755,7 +755,7 @@ def stream_download(url, fname, known_hash, downloader, pooch=None, retry_if_fai
     will retry the download the specified number of times in case the failure
     was due to a network error.
     """
-    import requests.exceptions
+    import requests.exceptions  # pylint: disable=C0415
 
     # Ensure the parent directory exists in case the file is in a subdirectory.
     # Otherwise, move will cause an error.

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -14,8 +14,6 @@ from pathlib import Path
 import shlex
 import shutil
 
-import requests
-import requests.exceptions
 
 from .hashes import hash_matches, file_hash
 from .utils import (
@@ -757,6 +755,8 @@ def stream_download(url, fname, known_hash, downloader, pooch=None, retry_if_fai
     will retry the download the specified number of times in case the failure
     was due to a network error.
     """
+    import requests.exceptions
+
     # Ensure the parent directory exists in case the file is in a subdirectory.
     # Otherwise, move will cause an error.
     if not fname.parent.exists():

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -190,7 +190,7 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
 
         """
         # Lazy import requests to speed up import time
-        import requests
+        import requests  # pylint: disable=C0415
 
         if check_only:
             response = requests.head(url, allow_redirects=True)
@@ -650,7 +650,7 @@ def doi_to_url(doi):
 
     """
     # Lazy import requests to speed up import time
-    import requests
+    import requests  # pylint: disable=C0415
 
     # Use doi.org to resolve the DOI to the repository website.
     response = requests.get(f"https://doi.org/{doi}")
@@ -750,7 +750,7 @@ class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstri
             The HTTP URL that can be used to download the file.
         """
         # Lazy import requests to speed up import time
-        import requests
+        import requests  # pylint: disable=C0415
 
         article_id = self.archive_url.split("/")[-1]
         # With the ID, we can get a list of files and their download links
@@ -811,7 +811,7 @@ class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docst
             The HTTP URL that can be used to download the file.
         """
         # Lazy import requests to speed up import time
-        import requests
+        import requests  # pylint: disable=C0415
 
         # Use the figshare API to find the article ID from the DOI
         article = requests.get(
@@ -856,7 +856,7 @@ class DataverseRepository(DataRepository):  # pylint: disable=missing-class-docs
             The resolved URL for the DOI
         """
         # Lazy import requests to speed up import time
-        import requests
+        import requests  # pylint: disable=C0415
 
         # Access the DOI as if this was a DataVerse instance
         parsed = parse_url(archive_url)
@@ -887,7 +887,7 @@ class DataverseRepository(DataRepository):  # pylint: disable=missing-class-docs
             The HTTP URL that can be used to download the file.
         """
         # Lazy import requests to speed up import time
-        import requests
+        import requests  # pylint: disable=C0415
 
         # Access the DOI as if this was a DataVerse instance
         parsed = parse_url(self.archive_url)

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -11,8 +11,6 @@ import os
 import sys
 import ftplib
 
-import requests
-
 from .utils import parse_url
 
 try:
@@ -191,6 +189,9 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
             is available on the server. Otherwise, returns ``None``.
 
         """
+        # Lazy import requests to speed up import time
+        import requests
+
         if check_only:
             response = requests.head(url, allow_redirects=True)
             available = bool(response.status_code == 200)
@@ -648,6 +649,9 @@ def doi_to_url(doi):
         The URL of the archive in the data repository.
 
     """
+    # Lazy import requests to speed up import time
+    import requests
+
     # Use doi.org to resolve the DOI to the repository website.
     response = requests.get(f"https://doi.org/{doi}")
     url = response.url
@@ -745,6 +749,9 @@ class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstri
         download_url : str
             The HTTP URL that can be used to download the file.
         """
+        # Lazy import requests to speed up import time
+        import requests
+
         article_id = self.archive_url.split("/")[-1]
         # With the ID, we can get a list of files and their download links
         article = requests.get(f"https://zenodo.org/api/records/{article_id}").json()
@@ -803,6 +810,8 @@ class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docst
         download_url : str
             The HTTP URL that can be used to download the file.
         """
+        # Lazy import requests to speed up import time
+        import requests
 
         # Use the figshare API to find the article ID from the DOI
         article = requests.get(
@@ -846,6 +855,8 @@ class DataverseRepository(DataRepository):  # pylint: disable=missing-class-docs
         archive_url : str
             The resolved URL for the DOI
         """
+        # Lazy import requests to speed up import time
+        import requests
 
         # Access the DOI as if this was a DataVerse instance
         parsed = parse_url(archive_url)
@@ -875,6 +886,8 @@ class DataverseRepository(DataRepository):  # pylint: disable=missing-class-docs
         download_url : str
             The HTTP URL that can be used to download the file.
         """
+        # Lazy import requests to speed up import time
+        import requests
 
         # Access the DOI as if this was a DataVerse instance
         parsed = parse_url(self.archive_url)


### PR DESCRIPTION
I'm proposing lazy loading requests since it adds a bit of import of.

Usually, I think that pooch is used as an import addon but not as a core feature. As such it is a little silly to expand the import time by alot. While small, it is not insignificant.

Thank you for considering

Current
![image](https://user-images.githubusercontent.com/90008/196042123-3e40875e-7bf0-47c8-9b81-dbd35ceaa686.png)

Proposed
![image](https://user-images.githubusercontent.com/90008/196042142-17e19272-dc22-452f-aaaa-2ef17c14068e.png)
