### PR TITLE
Improve docstring of `known_hash` in `retrieve` function

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -76,7 +76,7 @@ def retrieve(
     url : str
         The URL to the file that is to be downloaded. Ideally, the URL should
         end in a file name.
-    known_hash : str
+    known_hash : str or None
         A known hash (checksum) of the file. Will be used to verify the
         download or check if an existing file needs to be updated. By default,
         will assume it's a SHA256 hash. To specify a different hashing method,


### PR DESCRIPTION
Specify that `known_hash` can also be `None` in the `retrieve` function
docstring. This change helps some IDEs to identify `None` as a valid value for
the `known_hash` argument.


My IDE complains about None as being not allowed as described in the corresponding issue.
<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #332. 