### PR TITLE
Replace link to BibTeX citation with code snippet

### DIFF
--- a/CITATION.rst
+++ b/CITATION.rst
@@ -14,5 +14,20 @@ If you used Pooch in your research, please consider citing our paper:
 This is an open-access publication. The paper and the associated software
 review can be freely accessed at: https://doi.org/10.21105/joss.01943
 
-If you need a Bibtex entry for the paper, grab it here:
-https://www.doi2bib.org/bib/10.21105/joss.01943
+Here is a Bibtex entry to make things easier if you’re using Latex:
+
+.. code:: bibtex
+
+    @article{uieda2020,
+      title = {{Pooch}: {A} friend to fetch your data files},
+      author = {Leonardo Uieda and Santiago Soler and R{\'{e}}mi Rampin and Hugo van Kemenade and Matthew Turk and Daniel Shapero and Anderson Banihirwe and John Leeman},
+      year = {2020},
+      doi = {10.21105/joss.01943},
+      url = {https://doi.org/10.21105/joss.01943},
+      month = jan,
+      publisher = {The Open Journal},
+      volume = {5},
+      number = {45},
+      pages = {1943},
+      journal = {Journal of Open Source Software}
+    }


### PR DESCRIPTION
The link to doi2bib.org for a BibTeX entry for Pooch JOSS paper wasn't
working. Copied the snippet for creating the entry instead. Inspired on
Verde's CITATION.rst.
