### PR TITLE
Support DOIs with slashes in the filename

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,6 +13,7 @@ order by last name) and are considered "The Pooch Developers":
 * [Dominic Kempf](https://github.com/dokempf) - Scientific Software Center, Heidelberg University, Germany (ORCID: [0000-0002-6140-2332](https://www.orcid.org/0000-0002-6140-2332))
 * [Kacper Kowalik](https://github.com/Xarthisius) - National Center for Supercomputing Applications, University of Illinois at Urbana-Champaign, USA (ORCID: [0000-0003-1709-3744](https://www.orcid.org/0000-0003-1709-3744))
 * [John Leeman](https://github.com/jrleeman)
+* [Björn Ludwig](https://github.com/BjoernLudwigPTB) - Physikalisch-Technische Bundesanstalt, Germany (ORCID: [0000-0002-5910-9137](https://www.orcid.org/0000-0002-5910-9137))
 * [Daniel McCloy](https://github.com/drammock) - University of Washington, USA (ORCID: [0000-0002-7572-3241](https://orcid.org/0000-0002-7572-3241))
 * [Rémi Rampin](https://github.com/remram44) - New York University, USA (ORCID: [0000-0002-0524-2282](https://www.orcid.org/0000-0002-0524-2282))
 * [Clément Robert](https://github.com/neutrinoceros) - Institut de Planétologie et d'Astrophysique de Grenoble, France (ORCID: [0000-0001-8629-7068](https://orcid.org/0000-0001-8629-7068))

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -623,7 +623,7 @@ class DOIDownloader:  # pylint: disable=too-few-public-methods
             )
 
         # Resolve the URL
-        file_name = parsed_url["path"].split("/")[-1]
+        file_name = parsed_url["path"][1:]  # remove the leading slash in the path
         download_url = data_repository.download_url(file_name)
 
         # Instantiate the downloader object

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -142,11 +142,11 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
             },
         ),
         (
-            r"doi:10.5281/zenodo.7347607/Wild-Minds\/GreatApeDictionary-v1.1.zip",
+            r"doi:10.5281/zenodo.7632643/santisoler\/pooch-test-data-v1.zip",
             {
                 "protocol": "doi",
-                "netloc": "10.5281/zenodo.7347607",
-                "path": "/Wild-Minds/GreatApeDictionary-v1.1.zip",
+                "netloc": "10.5281/zenodo.7632643",
+                "path": "/santisoler/pooch-test-data-v1.zip",
             },
         ),
     ],

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -141,8 +141,16 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
                 "path": "/dike.json",
             },
         ),
+        (
+            r"doi:10.5281/zenodo.7347607/Wild-Minds\/GreatApeDictionary-v1.1.zip",
+            {
+                "protocol": "doi",
+                "netloc": "doi:10.5281/zenodo.7347607",
+                "path": "/Wild-Minds/GreatApeDictionary-v1.1.zip",
+            },
+        ),
     ],
-    ids=["http", "ftp", "doi"],
+    ids=["http", "ftp", "doi", "doi_slash-in-path"],
 )
 def test_parse_url(url, output):
     "Parse URL into 3 components"

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -145,7 +145,7 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
             r"doi:10.5281/zenodo.7347607/Wild-Minds\/GreatApeDictionary-v1.1.zip",
             {
                 "protocol": "doi",
-                "netloc": "doi:10.5281/zenodo.7347607",
+                "netloc": "10.5281/zenodo.7347607",
                 "path": "/Wild-Minds/GreatApeDictionary-v1.1.zip",
             },
         ),

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -146,7 +146,7 @@ def check_version(version, fallback="master"):
 
 
 def parse_url(url):
-    """
+    r"""
     Parse a URL into 3 components:
 
     <protocol>://<netloc>/<path>
@@ -159,6 +159,8 @@ def parse_url(url):
 
     The DOI is a special case. The protocol will be "doi", the netloc will be
     the DOI, and the path is what comes after the last "/".
+    Some DOI can store files with a forward slash "/" in their name, in those
+    cases we expect them to be lead by a backslash "\".
 
     Parameters
     ----------
@@ -178,9 +180,17 @@ def parse_url(url):
         )
     if url.startswith("doi:"):
         protocol = "doi"
-        parts = url[4:].split("/")
-        netloc = "/".join(parts[:-1])
-        path = "/" + parts[-1]
+        if r"\/" in url:
+            # Consider the special case in which the path has a forward slash
+            url = url[4:]
+            backslask_index = url.find(r"\/")
+            parts = url[:backslask_index].split("/")
+            netloc = "/".join(parts[:-1])
+            path = "/" + parts[-1] + url[backslask_index:].replace(r"\/", "/")
+        else:
+            parts = url[4:].split("/")
+            netloc = "/".join(parts[:-1])
+            path = "/" + parts[-1]
     else:
         parsed_url = urlsplit(url)
         protocol = parsed_url.scheme or "file"


### PR DESCRIPTION
Allow DOI downloaders to work with files uploaded to Zenodo that have a forward slash "/" in their name. These special cases are generated by the Zenodo-GitHub integration service, where the first portion of the filename matches the GitHub handle of the repository owned and the last portion matches the repository name. When creating the url to these repositories, the forward slashes that are part of the filename should be led by a backslash. For example: `url = "doi:10.123/zenodo.123123/my-file\/has-a-slash.zip"`.

**Relevant issues/PRs:**

Fixes #336


**Todo**

In case this patch works, we need to:

- [x] Try to add a file with a slash to our test repos in:
    - [x] Zenodo: [10.5281/zenodo.7632643](https://doi.org/10.5281/zenodo.7632643)
        - It was created through the Zenodo-GitHub integration service. By default the zip file includes the user handle, a forward slash and the repo name.
- [x] Update tests to see if we can download them
- [ ] Improve docs to instruct on how to use this feature
    - Extend the docstring of `DOIDownloader`
    - Extend the docstring of `retrieve`
    - Add an example in the user guide