### PR TITLE
Port from deprecated appdirs to platformdirs

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -53,7 +53,7 @@ manually.
 
 Required:
 
-* `appdirs <https://github.com/ActiveState/appdirs>`__
+* `platformdirs <https://github.com/platformdirs/platformdirs>`__
 * `packaging <https://github.com/pypa/packaging>`__
 * `requests <https://docs.python-requests.org/>`__
 

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     # Run
     - requests
     - packaging
-    - appdirs
+    - platformdirs
     # Build
     - build
     # Test

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -292,7 +292,6 @@ class FTPDownloader:  # pylint: disable=too-few-public-methods
         progressbar=False,
         chunk_size=1024,
     ):
-
         self.port = port
         self.username = username
         self.password = password

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -16,7 +16,7 @@ from urllib.parse import urlsplit
 from contextlib import contextmanager
 import warnings
 
-import appdirs
+import platformdirs
 from packaging.version import Version
 
 
@@ -74,10 +74,10 @@ def os_cache(project):
     r"""
     Default cache location based on the operating system.
 
-    The folder locations are defined by the ``appdirs``  package
+    The folder locations are defined by the ``platformdirs``  package
     using the ``user_cache_dir`` function.
     Usually, the locations will be following (see the
-    `appdirs documentation <https://github.com/ActiveState/appdirs>`__):
+    `platformdirs documentation <https://platformdirs.readthedocs.io>`__):
 
     * Mac: ``~/Library/Caches/<AppName>``
     * Unix: ``~/.cache/<AppName>`` or the value of the ``XDG_CACHE_HOME``
@@ -96,7 +96,7 @@ def os_cache(project):
         not expanded.
 
     """
-    return Path(appdirs.user_cache_dir(project))
+    return Path(platformdirs.user_cache_dir(project))
 
 
 def check_version(version, fallback="master"):

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ packages = find:
 python_requires = >=3.7
 setup_requires =
 install_requires =
-    appdirs>=1.3.0
+    platformdirs>=2.5.0
     packaging>=20.0
     requests>=2.19.0
 


### PR DESCRIPTION
This ports the uses (and mentions) of the deprecated `appdirs` to `platformdirs`. The APIs should be mostly equivalent (definitely for the ones used here) and `platformdirs` is already in use by most popular projects.