### PR TITLE
Support Zenodo urls with slashes in the filename

### DIFF
--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -622,7 +622,10 @@ class DOIDownloader:  # pylint: disable=too-few-public-methods
             )
 
         # Resolve the URL
-        file_name = parsed_url["path"].split("/")[-1]
+        file_name = parsed_url["path"]
+        # remove the leading slash in the path
+        if file_name[0] == "/":
+            file_name = file_name[1:]
         download_url = data_repository.download_url(file_name)
 
         # Instantiate the downloader object

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -28,6 +28,7 @@ from .utils import (
     data_over_ftp,
     pooch_test_figshare_url,
     pooch_test_zenodo_url,
+    pooch_test_zenodo_with_slash_url,
     pooch_test_dataverse_url,
     pooch_test_registry,
     check_tiny_data,
@@ -41,6 +42,7 @@ REGISTRY = pooch_test_registry()
 BASEURL = pooch_test_url()
 FIGSHAREURL = pooch_test_figshare_url()
 ZENODOURL = pooch_test_zenodo_url()
+ZENODOURL_W_SLASH = pooch_test_zenodo_with_slash_url()
 DATAVERSEURL = pooch_test_dataverse_url()
 REGISTRY_CORRUPTED = {
     # The same data file but I changed the hash manually to a wrong one
@@ -632,6 +634,26 @@ def test_load_registry_from_doi(url):
         assert len(pup.registry) == 2
         assert "tiny-data.txt" in pup.registry
         assert "store.zip" in pup.registry
+
+        # Ensure that all files have correct checksums by fetching them
+        for filename in pup.registry:
+            pup.fetch(filename)
+
+
+def test_load_registry_from_doi_zenodo_with_slash():
+    """
+    Check that the registry is correctly populated from the Zenodo API when
+    the filename contains a slash
+    """
+    url = ZENODOURL_W_SLASH
+    with TemporaryDirectory() as local_store:
+        path = os.path.abspath(local_store)
+        pup = Pooch(path=path, base_url=url)
+        pup.load_registry_from_doi()
+
+        # Check the existence of all files in the registry
+        assert len(pup.registry) == 1
+        assert "santisoler/pooch-test-data-v1.zip" in pup.registry
 
         # Ensure that all files have correct checksums by fetching them
         for filename in pup.registry:

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -42,6 +42,7 @@ from .utils import (
     data_over_ftp,
     pooch_test_figshare_url,
     pooch_test_zenodo_url,
+    pooch_test_zenodo_with_slash_url,
     pooch_test_dataverse_url,
 )
 
@@ -49,6 +50,7 @@ from .utils import (
 BASEURL = pooch_test_url()
 FIGSHAREURL = pooch_test_figshare_url()
 ZENODOURL = pooch_test_zenodo_url()
+ZENODOURL_W_SLASH = pooch_test_zenodo_with_slash_url()
 DATAVERSEURL = pooch_test_dataverse_url()
 
 
@@ -141,11 +143,11 @@ def test_zenodo_downloader_with_slash_in_fname():
     Related to issue #336
     """
     # Use the test data we have on the repository
-    url = r"doi:10.5281/zenodo.7632643/santisoler/pooch-test-data-v1.zip"
     with TemporaryDirectory() as local_store:
+        base_url = ZENODOURL_W_SLASH + "santisoler/pooch-test-data-v1.zip"
         downloader = DOIDownloader()
         outfile = os.path.join(local_store, "test-data.zip")
-        downloader(url, outfile, None)
+        downloader(base_url, outfile, None)
         # unpack the downloaded zip file so we can check the integrity of
         # tiny-data.txt
         fnames = Unzip()(outfile, action="download", pooch=None)

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -34,6 +34,7 @@ from ..downloaders import (
     DataverseRepository,
     doi_to_url,
 )
+from ..processors import Unzip
 from .utils import (
     pooch_test_url,
     check_large_data,
@@ -130,6 +131,26 @@ def test_doi_downloader(url):
         outfile = os.path.join(local_store, "tiny-data.txt")
         downloader(url + "tiny-data.txt", outfile, None)
         check_tiny_data(outfile)
+
+
+@pytest.mark.network
+def test_zenodo_downloader_with_slash_in_fname():
+    """
+    Test the Zenodo downloader when the path contains a forward slash
+
+    Related to issue #336
+    """
+    # Use the test data we have on the repository
+    url = r"doi:10.5281/zenodo.7632643/santisoler/pooch-test-data-v1.zip"
+    with TemporaryDirectory() as local_store:
+        downloader = DOIDownloader()
+        outfile = os.path.join(local_store, "test-data.zip")
+        downloader(url, outfile, None)
+        # unpack the downloaded zip file so we can check the integrity of
+        # tiny-data.txt
+        fnames = Unzip()(outfile, action="download", pooch=None)
+        (fname,) = [f for f in fnames if "tiny-data.txt" in f]
+        check_tiny_data(fname)
 
 
 @pytest.mark.network

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -141,8 +141,16 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
                 "path": "/dike.json",
             },
         ),
+        (
+            r"doi:10.5281/zenodo.7632643/santisoler/pooch-test-data-v1.zip",
+            {
+                "protocol": "doi",
+                "netloc": "10.5281/zenodo.7632643",
+                "path": "/santisoler/pooch-test-data-v1.zip",
+            },
+        ),
     ],
-    ids=["http", "ftp", "doi"],
+    ids=["http", "ftp", "doi", "zenodo-doi-with-slash"],
 )
 def test_parse_url(url, output):
     "Parse URL into 3 components"

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -98,6 +98,24 @@ def pooch_test_zenodo_url():
     return url
 
 
+def pooch_test_zenodo_with_slash_url():
+    """
+    Get base URL for test data in Zenodo, where the file name contains a slash
+
+    The URL contains the DOI for the Zenodo dataset that has a slash in the
+    filename (created with the GitHub-Zenodo integration service), using the
+    appropriate version for this version of Pooch.
+
+    Returns
+    -------
+    url
+        The URL for pooch's test data.
+
+    """
+    url = "doi:10.5281/zenodo.7632643/"
+    return url
+
+
 def pooch_test_dataverse_url():
     """
     Get the base URL for the test data stored on a DataVerse instance.

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -159,6 +159,10 @@ def parse_url(url):
 
     The DOI is a special case. The protocol will be "doi", the netloc will be
     the DOI, and the path is what comes after the last "/".
+    The only exception are Zenodo dois: the protocol will be "doi", the netloc
+    will be composed by the "prefix/suffix" and the path is what comes after
+    the second "/". This allows to support special cases of Zenodo dois where
+    the path contains forward slashes "/".
 
     Parameters
     ----------
@@ -179,8 +183,12 @@ def parse_url(url):
     if url.startswith("doi:"):
         protocol = "doi"
         parts = url[4:].split("/")
-        netloc = "/".join(parts[:-1])
-        path = "/" + parts[-1]
+        if "zenodo" in parts[1].lower():
+            netloc = "/".join(parts[:2])
+            path = "/" + "/".join(parts[2:])
+        else:
+            netloc = "/".join(parts[:-1])
+            path = "/" + parts[-1]
     else:
         parsed_url = urlsplit(url)
         protocol = parsed_url.scheme or "file"

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -162,7 +162,8 @@ def parse_url(url):
     The only exception are Zenodo dois: the protocol will be "doi", the netloc
     will be composed by the "prefix/suffix" and the path is what comes after
     the second "/". This allows to support special cases of Zenodo dois where
-    the path contains forward slashes "/".
+    the path contains forward slashes "/", created by the GitHub-Zenodo
+    integration service.
 
     Parameters
     ----------


### PR DESCRIPTION
Allow `DOIDownloader` to work with files uploaded to Zenodo that have a forward slash "/" in their name. These special cases are generated by the Zenodo-GitHub integration service, where the first portion of the filename matches the GitHub handle of the repository owned and the last portion matches the repository name. Now the `parse_url` function handles Zenodo dois under a special case: the netloc will be formed with the first two "parts" (`prefix/suffix`), while the path will be formed by everything that follows the second slash.


**Relevant issues/PRs:**

Fixes #336, fixes #341 and outperforms the idea drafted in #337
