### PR TITLE
Automatically add trailing slash to base_url on pooch.create

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -295,8 +295,8 @@ def create(
         Base URL for the remote data source. All requests will be made relative
         to this URL. The string should have a ``{version}`` formatting mark in
         it. We will call ``.format(version=version)`` on this string. If the
-        URL is a directory path, it must end in a ``'/'`` because we will not
-        include it.
+        URL does not end in a ``'/'``, a trailing ``'/'`` will be added
+        automatically.
     version : str or None
         The version string for your project. Should be PEP440 compatible. If
         None is given, will not attempt to format *base_url* and no subfolder
@@ -423,6 +423,8 @@ def create(
     path = cache_location(path, env, version)
     if isinstance(allow_updates, str):
         allow_updates = os.environ.get(allow_updates, "true").lower() != "false"
+    # add trailing "/"
+    base_url = base_url.rstrip("/") + "/"
     pup = Pooch(
         path=path,
         base_url=base_url,

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -26,6 +26,7 @@ from .utils import (
     temporary_file,
     os_cache,
     unique_file_name,
+    join_url,
 )
 from .downloaders import DOIDownloader, choose_downloader, doi_to_repository
 
@@ -617,7 +618,7 @@ class Pooch:
 
         """
         self._assert_file_in_registry(fname)
-        return self.urls.get(fname, "".join([self.base_url, fname]))
+        return self.urls.get(fname, join_url(self.base_url, fname))
 
     def load_registry(self, fname):
         """

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -26,7 +26,6 @@ from .utils import (
     temporary_file,
     os_cache,
     unique_file_name,
-    join_url,
 )
 from .downloaders import DOIDownloader, choose_downloader, doi_to_repository
 
@@ -618,7 +617,7 @@ class Pooch:
 
         """
         self._assert_file_in_registry(fname)
-        return self.urls.get(fname, join_url(self.base_url, fname))
+        return self.urls.get(fname, "".join([self.base_url, fname]))
 
     def load_registry(self, fname):
         """

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -382,6 +382,15 @@ def test_pooch_update_disallowed_environment():
         os.environ.pop(variable_name)
 
 
+def test_pooch_create_base_url_no_trailing_slash():
+    """
+    Test if pooch.create appends a trailing slash to the base url if missing
+    """
+    base_url = "https://mybase.url"
+    pup = create(base_url=base_url, registry=None, path=DATA_DIR)
+    assert pup.base_url == base_url + "/"
+
+
 @pytest.mark.network
 def test_pooch_corrupted(data_dir_mirror):
     "Raise an exception if the file hash doesn't match the registry"

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -145,10 +145,6 @@ def check_version(version, fallback="master"):
     return version
 
 
-def join_url(base_url, fname):
-    return base_url.rstrip("/") + "/" + fname
-
-
 def parse_url(url):
     """
     Parse a URL into 3 components:

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -145,6 +145,10 @@ def check_version(version, fallback="master"):
     return version
 
 
+def join_url(base_url, fname):
+    return base_url.rstrip("/") + "/" + fname
+
+
 def parse_url(url):
     """
     Parse a URL into 3 components:


### PR DESCRIPTION
Automatically add a trailing "/" to base_url in `pooch.create()` if missing. Update docstring and add test function that checks if the trailing slash gets added.

**Relevant issues/PRs:**

Fixes #324