### PR TITLE
Update version of Codecov's Action to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ on:
   schedule:
     # Run every Monday at 12:00 UTC
     # * is a special character in YAML so you have to quote this string
-    - cron:  '00 12 * * 1'
+    - cron: "00 12 * * 1"
 
 # Use bash by default in all jobs
 defaults:
@@ -28,7 +28,6 @@ defaults:
     shell: bash
 
 jobs:
-
   #############################################################################
   # Run tests and upload to codecov
   test:
@@ -148,9 +147,9 @@ jobs:
         run: coverage xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           env_vars: OS,PYTHON,DEPENDENCIES
           # Don't mark the job as failed if the upload fails for some reason.
           # It does sometimes but shouldn't be the reason for running


### PR DESCRIPTION
The v1 of Codecov's GitHub Action is deprecated and already started failing. Upgrading it to v3.
