### PR TITLE
Fixes quoting

### DIFF
--- a/pooch/tests/data/registry-quotes.txt
+++ b/pooch/tests/data/registry-quotes.txt
@@ -1,0 +1,6 @@
+foo'.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d
+bar'baz quux'.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d
+"foo bar.txt" baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d
+"foo bar2.txt" baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d http://myurl.com
+"foobar3.txt" baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d http://myurl.com
+foo'2.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d http://myurl.com

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -483,6 +483,19 @@ def test_pooch_load_registry_with_spaces():
     assert "other with spaces.txt" in pup.registry
 
 
+def test_pooch_load_registry_with_quotes():
+    "Verify that files with quotes in the name work"
+    pup = Pooch(path="", base_url="")
+    pup.load_registry(os.path.join(DATA_DIR, "registry-quotes.txt"))
+    assert "foo'.txt" in pup.registry  # vanilla single quote, no space
+    assert "bar'baz quux'.txt" in pup.registry  # quotes and spaces
+    assert '"foo bar.txt"' in pup.registry  # spaces, double quotes
+    assert '"foo bar2.txt"' in pup.registry  # double quotes, spaces, url
+    assert '"foobar3.txt"' in pup.registry  # double quotes, no spaces, url
+    assert "foo'2.txt" in pup.registry  # single quote, no space, url
+
+
+
 @pytest.mark.network
 def test_check_availability():
     "Should correctly check availability of existing and non existing files"


### PR DESCRIPTION
This PR restores the ability of filenames to contain quotes.

Implementing this required some modifications to the registry parser, as discussed in the issue thread for #357.

The dust isn't quite settled on this though; two of the existing tests are now failing:

```python
       2 failed
         - pooch/tests/test_core.py:471 test_pooch_load_registry_invalid_line
         - pooch/tests/test_core.py:478 test_pooch_load_registry_with_spaces
```
---
The first test fails as follows:
```python
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_pooch_load_registry_invalid_line ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

    def test_pooch_load_registry_invalid_line():
        "Should raise an exception when a line doesn't have two elements"
        pup = Pooch(path="", base_url="", registry={})
        with pytest.raises(IOError):
>           pup.load_registry(os.path.join(DATA_DIR, "registry-invalid.txt"))
E           Failed: DID NOT RAISE <class 'OSError'>

pooch/tests/test_core.py:475: Failed
```
This because the line
```
some-file.txt second_element third_element forth_element
```
Would be technically valid if `forth_element` is considered as the hash (it fails URL validation), and the remaining prefix of the line (`some-file.txt second_element third_element`) is taken as the filename.

This could be easily fixed by tightening the check on what constitutes a valid hash (eg hex strings with optional algorithm prefix), but one could easily devise a new test case that would pass there.  I think the correct behavior is actually to let this one parse.

---

The second test fails as follows:
```
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_pooch_load_registry_with_spaces ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

    def test_pooch_load_registry_with_spaces():
        "Should check that spaces in filenames are allowed in registry files"
        pup = Pooch(path="", base_url="")
        pup.load_registry(os.path.join(DATA_DIR, "registry-spaces.txt"))
>       assert "file with spaces.txt" in pup.registry
E       assert 'file with spaces.txt' in {'"file with spaces.txt"': 'baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d', 'other\\ with\\ spaces.txt': 'baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d'}
E        +  where {'"file with spaces.txt"': 'baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d', 'other\\ with\\ spaces.txt': 'baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d'} = <pooch.core.Pooch object at 0x7f93733cbb20>.registry

pooch/tests/test_core.py:482: AssertionError
```

This is because the surrounding quotes on the filename are no longer suppressed by the registry parser.  (This was the initial cause of my problem with #357.)

I'm actually not sure what the correct behavior here should be.  The old (<=1.6) behavior would be to leave the quotes in, in which case this test as written should fail.  The test could be revised so that the quotes are included in the search key.

OTOH, I see the logic in allowing quotes to encapsulate filenames like this.  Doing this correctly does require some sophisticated implementation (ie the guts of the shlex package) to get the escaping and matching logic right.  IMO it's overkill for what's needed here since the file format can only include one or two additional tokens (with no spaces in either) afterward.

Keeping filename parsing as literal as possible has a lot of advantages for simplicity, and seems less likely to surface unexpected behavior (eg suppressing quotes).

Unfortunately, I don't think it's possible to give a solution that's backward compatible with both 1.7.0 and 1.6 behavior, so I understand if the maintainers don't want to adopt the solution I've implemented here.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
Fixes #357
Also relevant to #313 

<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
