### PR TITLE
Fix for new zenodo API

### DIFF
--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -808,7 +808,7 @@ class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstri
         download_url : str
             The HTTP URL that can be used to download the file.
         """
-        files = {item["key"]: item for item in self.api_response["files"]}
+        files = {item["filename"]: item for item in self.api_response["files"]}
         if file_name not in files:
             raise ValueError(
                 f"File '{file_name}' not found in data archive {self.archive_url} (doi:{self.doi})."


### PR DESCRIPTION
Fixes #371. I find the new key by inspecting the response, not from a blessed official documentation... but it works...

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file 
in this repository (if available) and the general guidelines at 
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**

<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Example:
```python
import pooch

_GOSH_DOI = "10.5281/zenodo.7645765"
_GOSH_URL = f"doi:{_GOSH_DOI}/Segger_Guzzinati_Kohl_1.5.0.gosh"
_GOSH_KNOWN_HASH = "md5:7fee8891c147a4f769668403b54c529b"

gos_file_path = pooch.retrieve(
    url=_GOSH_URL,
    known_hash=_GOSH_KNOWN_HASH,
    progressbar=True,
)
```
