### PR TITLE
Fix bug: update Zenodo downloader for new API

### DIFF
--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -845,7 +845,7 @@ class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstri
         """
 
         for filedata in self.api_response["files"]:
-            pooch.registry[filedata["filename"]] = "md5:" + filedata["checksum"]
+            pooch.registry[filedata["filename"]] = f"md5:{filedata['checksum']}"
 
 
 class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docstring

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -819,7 +819,8 @@ class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstri
         filenames = [item["filename"] for item in self.api_response["files"]]
         if file_name not in filenames:
             raise ValueError(
-                f"File '{file_name}' not found in data archive {self.archive_url} (doi:{self.doi})."
+                f"File '{file_name}' not found in data archive "
+                f"{self.archive_url} (doi:{self.doi})."
             )
         # Build download url
         article_id = self.api_response["id"]

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -956,8 +956,7 @@ class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docst
         files = {item["name"]: item for item in self.api_response}
         if file_name not in files:
             raise ValueError(
-                f"File '{file_name}' not found in data archive "
-                f"{self.archive_url} (doi:{self.doi})."
+                f"File '{file_name}' not found in data archive {self.archive_url} (doi:{self.doi})."
             )
         download_url = files[file_name]["download_url"]
         return download_url


### PR DESCRIPTION
Update the Zenodo downloader to work with the new Zenodo API. Use the `filename` key for getting the filenames of all files in a repository. Update the generated download url based on heuristics: the link present in the API reference doesn't work at the moment). Update the method that populates the registry: use the new `filename` key and specify that the checksums are now md5.

**Relevant issues/PRs:**

Fixes #371
