### PR TITLE
Fix bug: add support for old and new Zenodo APIs

### DIFF
--- a/env/requirements-test.txt
+++ b/env/requirements-test.txt
@@ -2,4 +2,5 @@
 pytest
 pytest-cov
 pytest-localftpserver
+pytest-httpserver
 coverage

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
     - pytest
     - pytest-cov
     - pytest-localftpserver
+    - pytest-httpserver
     - coverage
     # Documentation
     - sphinx==4.4.*

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -748,6 +748,9 @@ class DataRepository:  # pylint: disable=too-few-public-methods, missing-class-d
 
 
 class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstring
+
+    base_api_url = "https://zenodo.org/api/records"
+
     def __init__(self, doi, archive_url):
         self.archive_url = archive_url
         self.doi = doi
@@ -789,7 +792,7 @@ class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstri
 
             article_id = self.archive_url.split("/")[-1]
             self._api_response = requests.get(
-                f"https://zenodo.org/api/records/{article_id}"
+                f"{self.base_api_url}/{article_id}"
             ).json()
 
         return self._api_response

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -845,7 +845,7 @@ class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstri
         """
 
         for filedata in self.api_response["files"]:
-            pooch.registry[filedata["filename"]] = "md5:" + filedata["checksum"]
+            pooch.registry[filedata["filename"]] = f"md5:{filedata['checksum']}"
 
 
 class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docstring

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -819,7 +819,8 @@ class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstri
         filenames = [item["filename"] for item in self.api_response["files"]]
         if file_name not in filenames:
             raise ValueError(
-                f"File '{file_name}' not found in data archive {self.archive_url} (doi:{self.doi})."
+                f"File '{file_name}' not found in data archive "
+                f"{self.archive_url} (doi:{self.doi})."
             )
         # Build download url
         article_id = self.api_response["id"]

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -956,8 +956,7 @@ class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docst
         files = {item["name"]: item for item in self.api_response}
         if file_name not in files:
             raise ValueError(
-                f"File '{file_name}' not found in data archive "
-                f"{self.archive_url} (doi:{self.doi})."
+                f"File '{file_name}' not found in data archive {self.archive_url} (doi:{self.doi})."
             )
         download_url = files[file_name]["download_url"]
         return download_url

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -748,7 +748,6 @@ class DataRepository:  # pylint: disable=too-few-public-methods, missing-class-d
 
 
 class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstring
-
     base_api_url = "https://zenodo.org/api/records"
 
     def __init__(self, doi, archive_url):

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -489,7 +489,7 @@ class TestZenodoAPISupport:
         else:
             msg = "Couldn't determine the version of the Zenodo API"
             with pytest.raises(ValueError, match=msg):
-                downloader.api_version
+                api_version = downloader.api_version
 
     @pytest.mark.parametrize(
         "api_version, api_response",
@@ -519,10 +519,10 @@ class TestZenodoAPISupport:
             assert download_url == expected_url
 
     @pytest.mark.parametrize(
-        "api_version, api_response",
-        [("legacy", legacy_api_response), ("new", new_api_response)],
+        "api_response",
+        [legacy_api_response, new_api_response],
     )
-    def test_populate_registry(self, httpserver, tmp_path, api_version, api_response):
+    def test_populate_registry(self, httpserver, tmp_path, api_response):
         """
         Test if population of registry is correctly done for each API version.
         """

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -23,6 +23,7 @@ try:
 except ImportError:
     paramiko = None
 
+from .. import Pooch
 from ..downloaders import (
     HTTPDownloader,
     FTPDownloader,
@@ -384,3 +385,157 @@ def test_downloader_arbitrary_progressbar(capsys):
 
         # Check that the downloaded file has the right content
         check_large_data(outfile)
+
+
+class TestZenodoAPISupport:
+    """
+    Test support for different Zenodo APIs
+    """
+
+    article_id = 123456
+    doi = f"10.0001/zenodo.{article_id}"
+    doi_url = f"https://doi.org/{doi}"
+    file_name = "my-file.zip"
+    file_url = (
+        "https://zenodo.org/api/files/513d7033-93a2-4eeb-821c-2fb0bbab0012/my-file.zip"
+    )
+    file_checksum = "2942bfabb3d05332b66eb128e0842cff"
+
+    legacy_api_response = dict(
+        created="2021-20-19T08:00:00.000000+00:00",
+        modified="2021-20-19T08:00:00.000000+00:00",
+        id=article_id,
+        doi=doi,
+        doi_url=doi_url,
+        files=[
+            {
+                "id": "513d7033-93a2-4eeb-821c-2fb0bbab0012",
+                "key": file_name,
+                "checksum": f"md5:{file_checksum}",
+                "links": {
+                    "self": file_url,
+                },
+            }
+        ],
+    )
+
+    new_api_response = dict(
+        created="2021-20-19T08:00:00.000000+00:00",
+        modified="2021-20-19T08:00:00.000000+00:00",
+        id=article_id,
+        doi=doi,
+        doi_url=doi_url,
+        files=[
+            {
+                "id": "513d7033-93a2-4eeb-821c-2fb0bbab0012",
+                "filename": file_name,
+                "checksum": file_checksum,
+                "links": {
+                    "self": file_url,
+                },
+            }
+        ],
+    )
+
+    invalid_api_response = dict(
+        created="2021-20-19T08:00:00.000000+00:00",
+        modified="2021-20-19T08:00:00.000000+00:00",
+        id=article_id,
+        doi=doi,
+        doi_url=doi_url,
+        files=[
+            {
+                "id": "513d7033-93a2-4eeb-821c-2fb0bbab0012",
+                "filename": file_name,
+                "checksum": file_checksum,
+                "links": {
+                    "self": file_url,
+                },
+            },
+            {
+                "id": "513d7033-93a2-4eeb-821c-2fb0bbab0012",
+                "key": file_name,
+                "checksum": f"md5:{file_checksum}",
+                "links": {
+                    "self": file_url,
+                },
+            },
+        ],
+    )
+
+    @pytest.mark.parametrize(
+        "api_version, api_response",
+        [
+            ("legacy", legacy_api_response),
+            ("new", new_api_response),
+            ("invalid", invalid_api_response),
+        ],
+    )
+    def test_api_version(self, httpserver, api_version, api_response):
+        """
+        Test if the API version is correctly detected.
+        """
+        # Create a local http server
+        httpserver.expect_request(f"/zenodo.{self.article_id}").respond_with_json(
+            api_response
+        )
+        # Create Zenodo downloader
+        downloader = ZenodoRepository(doi=self.doi, archive_url=self.doi_url)
+        # Override base url for the API of the downloader
+        downloader.base_api_url = httpserver.url_for("")
+        # Check if the API version is correctly identified
+        if api_version != "invalid":
+            assert downloader.api_version == api_version
+        else:
+            msg = "Couldn't determine the version of the Zenodo API"
+            with pytest.raises(ValueError, match=msg):
+                downloader.api_version
+
+    @pytest.mark.parametrize(
+        "api_version, api_response",
+        [("legacy", legacy_api_response), ("new", new_api_response)],
+    )
+    def test_download_url(self, httpserver, api_version, api_response):
+        """
+        Test if the download url is correct for each API version.
+        """
+        # Create a local http server
+        httpserver.expect_request(f"/zenodo.{self.article_id}").respond_with_json(
+            api_response
+        )
+        # Create Zenodo downloader
+        downloader = ZenodoRepository(doi=self.doi, archive_url=self.doi_url)
+        # Override base url for the API of the downloader
+        downloader.base_api_url = httpserver.url_for("")
+        # Check if the download url is correct
+        download_url = downloader.download_url(file_name=self.file_name)
+        if api_version == "legacy":
+            assert download_url == self.file_url
+        else:
+            expected_url = (
+                "https://zenodo.org/records/"
+                f"{self.article_id}/files/{self.file_name}?download=1"
+            )
+            assert download_url == expected_url
+
+    @pytest.mark.parametrize(
+        "api_version, api_response",
+        [("legacy", legacy_api_response), ("new", new_api_response)],
+    )
+    def test_populate_registry(self, httpserver, tmp_path, api_version, api_response):
+        """
+        Test if population of registry is correctly done for each API version.
+        """
+        # Create a local http server
+        httpserver.expect_request(f"/zenodo.{self.article_id}").respond_with_json(
+            api_response
+        )
+        # Create sample pooch object
+        puppy = Pooch(base_url="", path=tmp_path)
+        # Create Zenodo downloader
+        downloader = ZenodoRepository(doi=self.doi, archive_url=self.doi_url)
+        # Override base url for the API of the downloader
+        downloader.base_api_url = httpserver.url_for("")
+        # Populate registry
+        downloader.populate_registry(puppy)
+        assert puppy.registry == {self.file_name: f"md5:{self.file_checksum}"}


### PR DESCRIPTION
Allow the Zenodo downloader class to work both with the previous Zenodo API and the new API that is running since their migration to InvenioRDM on 2023-10-13. The downloader class `ZenodoRepository` determines which API version is interacting with and defines the download url and populate the registry based on that. Test if `ZenodoRepository` correctly supports both the old and new Zenodo APIs. Use `pytest-httpserver` to run a local server that returns API response that mimics the Zenodo ones. Define a `base_api_url` class attribute for `ZenodoRepository` so we can override it in tests.

<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**

Fixes #371


Related to #373

This PR was triggered by discussions on the [Fatiando Meeting of 2023-10-19](https://github.com/fatiando/community/blob/main/community-calls/2023.md#2023-10-19).
