### PR TITLE
Add back setup.py to get GitHub info on dependents

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ exclude .gitignore
 exclude .gitattributes
 exclude environment.yml
 exclude license_notice.py
+include pooch/tests/data

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2018 The Pooch Developers.
+# Distributed under the terms of the BSD 3-Clause License.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# This code is part of the Fatiando a Terra project (https://www.fatiando.org)
+#
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
GitHub only shows packages and repositories that depend on Pooch when there is a `setup.py` file in the repository. Add one back that just calls `setup()` so we can access that feature.


