### PR TITLE
Mark additional tests requiring network

### DIFF
--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -525,12 +525,9 @@ def test_check_availability_invalid_downloader():
         return None
 
     pup = Pooch(path=DATA_DIR, base_url=BASEURL, registry=REGISTRY)
-    # First check that everything works without the custom downloader
-    assert pup.is_available("tiny-data.txt")
-    # Now use the bad one
-    with pytest.raises(NotImplementedError) as error:
+    msg = "does not support availability checks."
+    with pytest.raises(NotImplementedError, match=msg):
         pup.is_available("tiny-data.txt", downloader=downloader)
-        assert "does not support availability checks" in str(error)
 
 
 @pytest.mark.network
@@ -632,6 +629,7 @@ def test_stream_download(fname):
     [FIGSHAREURL, ZENODOURL, DATAVERSEURL],
     ids=["figshare", "zenodo", "dataverse"],
 )
+@pytest.mark.network
 def test_load_registry_from_doi(url):
     """Check that the registry is correctly populated from the API"""
     with TemporaryDirectory() as local_store:
@@ -649,6 +647,7 @@ def test_load_registry_from_doi(url):
             pup.fetch(filename)
 
 
+@pytest.mark.network
 def test_load_registry_from_doi_zenodo_with_slash():
     """
     Check that the registry is correctly populated from the Zenodo API when

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -624,12 +624,12 @@ def test_stream_download(fname):
         check_tiny_data(str(destination))
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     "url",
     [FIGSHAREURL, ZENODOURL, DATAVERSEURL],
     ids=["figshare", "zenodo", "dataverse"],
 )
-@pytest.mark.network
 def test_load_registry_from_doi(url):
     """Check that the registry is correctly populated from the API"""
     with TemporaryDirectory() as local_store:

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -86,6 +86,7 @@ def test_unsupported_protocol():
         choose_downloader("doii:XXX/XXX/file")
 
 
+@pytest.mark.network
 def test_invalid_doi_repository():
     "Should fail if data repository is not supported"
     with pytest.raises(ValueError) as exc:
@@ -96,6 +97,7 @@ def test_invalid_doi_repository():
     assert "Invalid data repository 'joss.theoj.org'" in str(exc.value)
 
 
+@pytest.mark.network
 def test_doi_url_not_found():
     "Should fail if the DOI is not found"
     with pytest.raises(ValueError) as exc:
@@ -112,6 +114,7 @@ def test_doi_url_not_found():
     ],
     ids=["figshare", "zenodo", "dataverse"],
 )
+@pytest.mark.network
 def test_figshare_url_file_not_found(repository, doi):
     "Should fail if the file is not found in the archive"
     with pytest.raises(ValueError) as exc:
@@ -126,6 +129,7 @@ def test_figshare_url_file_not_found(repository, doi):
     [FIGSHAREURL, ZENODOURL, DATAVERSEURL],
     ids=["figshare", "zenodo", "dataverse"],
 )
+@pytest.mark.network
 def test_doi_downloader(url):
     "Test the DOI downloader"
     # Use the test data we have on the repository

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -105,6 +105,7 @@ def test_doi_url_not_found():
     assert "Is the DOI correct?" in str(exc.value)
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     "repository,doi",
     [
@@ -114,7 +115,6 @@ def test_doi_url_not_found():
     ],
     ids=["figshare", "zenodo", "dataverse"],
 )
-@pytest.mark.network
 def test_figshare_url_file_not_found(repository, doi):
     "Should fail if the file is not found in the archive"
     with pytest.raises(ValueError) as exc:
@@ -124,12 +124,12 @@ def test_figshare_url_file_not_found(repository, doi):
     assert "File 'bla.txt' not found" in str(exc.value)
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     "url",
     [FIGSHAREURL, ZENODOURL, DATAVERSEURL],
     ids=["figshare", "zenodo", "dataverse"],
 )
-@pytest.mark.network
 def test_doi_downloader(url):
     "Test the DOI downloader"
     # Use the test data we have on the repository


### PR DESCRIPTION
Those tests also require network and should be excluded when running
`pytest -m 'not network'`.

**Summary for Squash and Merge**

Add `network` pytest mark to test functions that require network connection to hit third party servers. Improve `test_check_availability_invalid_downloader` to remove the need to use network connection just to test an error raised after an invalid argument to a custom downloader.