### PR TITLE
Add optional dependencies to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,10 @@ dependencies:
     - requests
     - packaging
     - platformdirs
+    # Optional dependencies
+    - tqdm>=4.41.0,<5.0.0
+    - paramiko>=2.7.0
+    - xxhash>=1.4.3
     # Build
     - build
     # Test


### PR DESCRIPTION
Include Pooch's optional dependencies to `environment.yml`. This allows to run the full suite of tests after creating the environment and installing Pooch with `make install`.
