### PR TITLE
Run tests with oldest dependencies on x86 macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,16 +29,16 @@ jobs:
   test:
     name: ${{ matrix.os }} python=${{ matrix.python }} dependencies=${{ matrix.dependencies }}
     if: ${{ github.repository_owner == 'fatiando' || github.event_name != 'schedule' }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       # Otherwise, the workflow would stop if a single job fails. We want to
       # run all of them to catch failures in different combinations.
       fail-fast: false
       matrix:
         os:
-          - ubuntu
-          - macos
-          - windows
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
         dependencies:
           - oldest
           - latest
@@ -50,6 +50,14 @@ jobs:
             python: "3.11"
           - dependencies: optional
             python: "3.11"
+          # test on macos-13 (x86) using oldest dependencies and python 3.7
+          - os: macos-13
+            dependencies: oldest
+            python: "3.7"
+        exclude:
+          # don't test on macos-latest (arm64) with oldest dependencies
+          - os: macos-latest
+            dependencies: oldest
     env:
       REQUIREMENTS: env/requirements-build.txt env/requirements-test.txt
       # Used to tag codecov submissions


### PR DESCRIPTION
Change configuration of tests in GitHub Actions: use the latest x86 macos runner with the `oldest` dependencies and Python 3.7. Use the latest macos runner (arm64) only against the `latest` and `optional` requirements. This fixes CI failing because there are not Numpy binaries in PyPI for arm64 and compatible with Python 3.7.


**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Inspired in fatiando/harmonica#499
