### PR TITLE
Exclude doc/ from wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,9 @@ xxhash = ["xxhash>=1.4.3"]
 "Bug Tracker" = "https://github.com/fatiando/pooch/issues"
 "Source Code" = "https://github.com/fatiando/pooch"
 
-[tool.setuptools.packages]
-find = {}  # Scanning implicit namespaces is active by default
+[tool.setuptools.packages.find]
+# Scanning implicit namespaces is active by default
+exclude = ["doc*"]
 
 [tool.setuptools.package-data]
 "pooch.tests.data" = ["*.txt", "*.zip", "*.gz", "*.xz", "*.bz2"]


### PR DESCRIPTION
The automatic discovery adds doc/ to the wheel triggered by the
presence of `conf.py` in that directory.
