### PR TITLE
Fix xxhash optional requirement in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,8 @@ dependencies:
     # Optional dependencies
     - tqdm>=4.41.0,<5.0.0
     - paramiko>=2.7.0
-    - xxhash>=1.4.3
+    - python-xxhash>=1.4.3  # in conda-forge python-xxhash is the python pkg
+    - xxhash # this is the xxHash library in conda-forge
     # Build
     - build
     # Test


### PR DESCRIPTION
Fix the name of the package for installing `xxhash` in `environment.yml`. In conda forge, `xxhash` is the package that provides the binaries for the hash algorithm, while `python-xxhash` provides the Python wrapper (the same package as `xxhash` in PyPI).
