### PR TITLE
Replace `build` for `python-build` in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
     - python-xxhash>=1.4.3  # in conda-forge python-xxhash is the python pkg
     - xxhash # this is the xxHash library in conda-forge
     # Build
-    - build
+    - python-build
     # Test
     - pytest
     - pytest-cov


### PR DESCRIPTION
The `build` package in `conda-forge` is outdated, `python-build` should be used instead.
