### PR TITLE
Increase the max positional args allowed by pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -332,6 +332,9 @@ max-statements=50
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2
 
+# Increase maximum positional arguemnts
+max-positional-arguments=9
+
 
 [IMPORTS]
 


### PR DESCRIPTION
Configure `pylint` to increase the maximum number of positional arguments allowed in any function or method.
