### PR TITLE
Add support for NIST Public Data Reposity DOIs

### DIFF
--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -7,7 +7,9 @@
 """
 Test the downloader classes and functions separately from the Pooch core.
 """
+import hashlib
 import os
+import re
 import sys
 from tempfile import TemporaryDirectory
 
@@ -33,6 +35,7 @@ from ..downloaders import (
     FigshareRepository,
     ZenodoRepository,
     DataverseRepository,
+    NISTPDRRepository,
     doi_to_url,
 )
 from ..processors import Unzip
@@ -45,6 +48,8 @@ from .utils import (
     pooch_test_zenodo_url,
     pooch_test_zenodo_with_slash_url,
     pooch_test_dataverse_url,
+    pooch_test_nist_pdr_url,
+    pooch_test_nist_pdr_nested_file,
 )
 
 
@@ -138,6 +143,91 @@ def test_doi_downloader(url):
         outfile = os.path.join(local_store, "tiny-data.txt")
         downloader(url + "tiny-data.txt", outfile, None)
         check_tiny_data(outfile)
+
+
+@pytest.mark.network
+def test_doi_downloader_nist_pdr():
+    """
+    Test the DOI downloader for the NIST PDR.
+
+    The NIST PDR does not have a record with 'tiny-data.txt',
+    so uses a slightly different test implementation than test_doi_downloader()
+    """
+    with TemporaryDirectory() as local_store:
+        downloader = DOIDownloader()
+        outfile = os.path.join(local_store, "README.txt")
+        to_download = pooch_test_nist_pdr_url("simple") + "README.txt"
+        downloader(to_download, outfile, None)
+
+        assert os.path.exists(outfile)
+        with open(outfile, encoding="utf-8") as tinydata:
+            content = tinydata.read()
+        true_content = "The `labbench` python library provides tools for instrument automation"
+        assert content.strip()[:70] == true_content
+
+
+@pytest.mark.network
+def test_doi_downloader_nist_pdr_file_in_collection():
+    """
+    Test the DOI downloader for the NIST PDR.
+
+    This test tests a file deeper in a nested collection
+    """
+    with TemporaryDirectory() as local_store:
+        downloader = DOIDownloader()
+        file_path = pooch_test_nist_pdr_nested_file()["filename"]
+        outfile = os.path.join(local_store, file_path.rsplit("/", maxsplit=1)[-1])
+        to_download = pooch_test_nist_pdr_url("nested_collection") + file_path
+        downloader(to_download, outfile, None)
+
+        assert os.path.exists(outfile)
+        with open(outfile, "rb") as tinydata:
+            assert (
+                hashlib.sha256(tinydata.read()).hexdigest()
+                == pooch_test_nist_pdr_nested_file()["checksum"][7:]
+            )
+
+
+@pytest.mark.network
+def test_doi_downloader_nist_pdr_missing_file():
+    """
+    Test the DOI downloader for the NIST PDR.
+
+    This test tests a file deeper in a nested collection
+    """
+    with TemporaryDirectory() as local_store:
+        downloader = DOIDownloader()
+        file_path = "nonexistent_file.txt"
+        outfile = os.path.join(local_store, file_path.rsplit("/", maxsplit=1)[-1])
+        to_download = pooch_test_nist_pdr_url("nested_collection") + file_path
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "File 'nonexistent_file.txt' not found in data archive "
+                "https://data.nist.gov/od/id/8C40CFA7931709DAE0532457068179072082 "
+                "(doi:10.18434/M32082).",
+            ),
+        ):
+            downloader(to_download, outfile, None)
+
+
+def test_populate_registry_nist_pdr(tmp_path):
+    """
+    Test if population of registry is correctly done for NIST PDR.
+    """
+    # Create sample pooch object
+    puppy = Pooch(base_url="", path=tmp_path)
+    _doi = "10.18434/M32082"
+    _doi_url = doi_to_url(_doi)
+    # Create NIST PDR downloader
+    downloader = NISTPDRRepository(doi=_doi, archive_url=_doi_url)
+    # Populate registry
+    downloader.populate_registry(puppy)
+    assert len(puppy.registry) == 101
+    assert (
+        puppy.registry[pooch_test_nist_pdr_nested_file()["filename"]]
+        == pooch_test_nist_pdr_nested_file()["checksum"]
+    )
 
 
 @pytest.mark.network

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -128,6 +128,37 @@ def pooch_test_dataverse_url():
     return url
 
 
+def pooch_test_nist_pdr_url(file_type="simple"):
+    """
+    Get the base URL for test data stored on the NIST Public Data Repository.
+
+    Returns
+    -------
+    url
+        The URL for pooch's test data.
+    """
+    urls = {
+        "simple": "doi:10.18434/M32122/",
+        "nested_collection": "doi:10.18434/M32082/"
+    }
+    return urls[file_type]
+
+
+def pooch_test_nist_pdr_nested_file():
+    """
+    Get filename and checksum for a nested file stored on the NIST PDR.
+
+    Returns
+    -------
+    dict
+        Dictionary containing the filename and checksum for a test data file.
+    """
+    return {
+        "filename": "EDS/Figure 5 - Point Scans/EDS Objects Supplement Raw Data/CSL/CSL_SQ.xlsx",
+        "checksum": "sha256:5867c7048743c4814d68e09b3738cd9b90a5bab102cec87126c77b2924e1070b",
+    }
+
+
 def pooch_test_registry():
     """
     Get a registry for the test data used in Pooch itself.

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -159,11 +159,11 @@ def parse_url(url):
 
     The DOI is a special case. The protocol will be "doi", the netloc will be
     the DOI, and the path is what comes after the last "/".
-    The only exception are Zenodo dois: the protocol will be "doi", the netloc
-    will be composed by the "prefix/suffix" and the path is what comes after
-    the second "/". This allows to support special cases of Zenodo dois where
-    the path contains forward slashes "/", created by the GitHub-Zenodo
-    integration service.
+    The only exception are Zenodo and NIST PDR dois: the protocol will be
+    "doi", the netloc will be composed by the "prefix/suffix" and the path is
+    what comes after the second "/". This allows to support special cases of
+    Zenodo dois where the path contains forward slashes "/", created by the
+    GitHub-Zenodo integration service.
 
     Parameters
     ----------
@@ -184,7 +184,7 @@ def parse_url(url):
     if url.startswith("doi:"):
         protocol = "doi"
         parts = url[4:].split("/")
-        if "zenodo" in parts[1].lower():
+        if "zenodo" in parts[1].lower() or "10.18434" in parts:
             netloc = "/".join(parts[:2])
             path = "/" + "/".join(parts[2:])
         else:


### PR DESCRIPTION
This PR implements a DOI downloader for the NIST public data repository at https://data.nist.gov

This is my first attempt at developing on pooch at all, so please let me know if there are any changes needed, but I have included tests, and it is working so far as I can tell. Happy to iterate as needed.

**Relevant issues/PRs:**

Fixes #441 