### PR TITLE
Start replacing pylint, flake8 and black for ruff

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -58,4 +58,4 @@ jobs:
         run: python -m pip freeze
 
       - name: Check code style
-        run: make check-style lint
+        run: make check-style

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ help:
 	@echo "  test      run the test suite (including doctests) and report coverage"
 	@echo "  format    automatically format the code"
 	@echo "  check     run code style and quality checks"
-	@echo "  lint      run pylint for a deeper (and slower) quality check"
 	@echo "  build     build source and wheel distributions"
 	@echo "  clean     clean up build and generated files"
 	@echo ""
@@ -31,20 +30,18 @@ test:
 	rm -r $(TESTDIR)
 
 format:
-	black $(CHECK_STYLE)
+	ruff check --select I --fix $(CHECK_STYLE) # autoformat with isort
+	ruff format $(CHECK_STYLE)
 	burocrata --extension=py $(CHECK_STYLE)
 
 check: check-format check-style
 
 check-format:
-	black --check $(CHECK_STYLE)
+	ruff format --check $(CHECK_STYLE)
 	burocrata --check --extension=py $(CHECK_STYLE)
 
 check-style:
-	flake8 $(CHECK_STYLE)
-
-lint:
-	pylint --jobs=0 $(LINT_FILES)
+	ruff check $(CHECK_STYLE)
 
 clean:
 	find . -name "*.pyc" -exec rm -v {} \;

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,11 +4,10 @@
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
-import os
 import datetime
+import os
 
 import pooch
-
 
 # Project information
 # -----------------------------------------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,7 +5,6 @@
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
 import datetime
-import os
 
 import pooch
 

--- a/env/requirements-style.txt
+++ b/env/requirements-style.txt
@@ -1,6 +1,3 @@
 # Style checks
-black
-flake8
-pylint>=2.4
-pathspec
+ruff
 burocrata

--- a/environment.yml
+++ b/environment.yml
@@ -27,9 +27,6 @@ dependencies:
     - sphinx-book-theme==1.1.*
     - sphinx-design==0.5.*
     # Style
-    - pathspec
-    - black>=20.8b1
-    - flake8
-    - pylint>=2.4
+    - ruff
     - pip:
       - burocrata

--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -7,20 +7,18 @@
 # pylint: disable=missing-docstring,import-outside-toplevel,import-self
 #
 # Import functions/classes to make the API
-from .core import Pooch, create, retrieve
-from .utils import os_cache, check_version, get_logger
-from .hashes import file_hash, make_registry
-from .downloaders import (
-    HTTPDownloader,
-    FTPDownloader,
-    SFTPDownloader,
-    DOIDownloader,
-)
-from .processors import Unzip, Untar, Decompress
-
 # This file is generated automatically by setuptools_scm
 from . import _version
-
+from .core import Pooch, create, retrieve
+from .downloaders import (
+    DOIDownloader,
+    FTPDownloader,
+    HTTPDownloader,
+    SFTPDownloader,
+)
+from .hashes import file_hash, make_registry
+from .processors import Decompress, Untar, Unzip
+from .utils import check_version, get_logger, os_cache
 
 # Add a "v" to the version number
 __version__ = f"v{_version.version}"

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -659,7 +659,7 @@ class Pooch:
                     continue
 
                 elements = shlex.split(line)
-                if not len(elements) in [0, 2, 3]:
+                if len(elements) not in [0, 2, 3]:
                     raise OSError(
                         f"Invalid entry in Pooch registry file '{fname}': "
                         f"expected 2 or 3 elements in line {linenum + 1} but got "

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -7,25 +7,25 @@
 """
 The main Pooch class and a factory function for it.
 """
-import os
-import time
+
 import contextlib
-from pathlib import Path
+import os
 import shlex
 import shutil
+import time
+from pathlib import Path
 
-
-from .hashes import hash_matches, file_hash
+from .downloaders import DOIDownloader, choose_downloader, doi_to_repository
+from .hashes import file_hash, hash_matches
 from .utils import (
+    cache_location,
     check_version,
     get_logger,
     make_local_storage,
-    cache_location,
-    temporary_file,
     os_cache,
+    temporary_file,
     unique_file_name,
 )
-from .downloaders import DOIDownloader, choose_downloader, doi_to_repository
 
 
 def retrieve(

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -985,6 +985,7 @@ class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docst
                     "the repository should be used. "
                     "Figshare will point to the latest version available.",
                     UserWarning,
+                    stacklevel=2,
                 )
                 # Define API url using only the article id
                 # (figshare will resolve the latest version)

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -7,10 +7,10 @@
 """
 The classes that actually handle the downloads.
 """
+
+import ftplib
 import os
 import sys
-import ftplib
-
 import warnings
 
 from .utils import parse_url
@@ -171,9 +171,7 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
         if self.progressbar is True and tqdm is None:
             raise ValueError("Missing package 'tqdm' required for progress bars.")
 
-    def __call__(
-        self, url, output_file, pooch, check_only=False
-    ):  # pylint: disable=R0914
+    def __call__(self, url, output_file, pooch, check_only=False):  # pylint: disable=R0914
         """
         Download the given URL over HTTP to the given output file.
 

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -1022,7 +1022,8 @@ class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docst
         files = {item["name"]: item for item in self.api_response}
         if file_name not in files:
             raise ValueError(
-                f"File '{file_name}' not found in data archive {self.archive_url} (doi:{self.doi})."
+                f"File '{file_name}' not found in data archive {self.archive_url} "
+                f"(doi:{self.doi})."
             )
         download_url = files[file_name]["download_url"]
         return download_url

--- a/pooch/hashes.py
+++ b/pooch/hashes.py
@@ -7,8 +7,9 @@
 """
 Calculating and checking file hashes.
 """
-import hashlib
+
 import functools
+import hashlib
 from pathlib import Path
 
 # From the docs: https://docs.python.org/3/library/hashlib.html#hashlib.new

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -8,14 +8,15 @@
 """
 Post-processing hooks
 """
+
 import abc
-import os
 import bz2
 import gzip
 import lzma
+import os
 import shutil
-from zipfile import ZipFile
 from tarfile import TarFile
+from zipfile import ZipFile
 
 from .utils import get_logger
 

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -8,6 +8,7 @@
 """
 Test the core class and factory function.
 """
+
 import hashlib
 import os
 from pathlib import Path
@@ -15,26 +16,24 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from ..core import create, Pooch, retrieve, download_action, stream_download
-from ..utils import get_logger, temporary_file, os_cache
-from ..hashes import file_hash, hash_matches
-
 # Import the core module so that we can monkeypatch some functions
 from .. import core
-from ..downloaders import HTTPDownloader, FTPDownloader
-
+from ..core import Pooch, create, download_action, retrieve, stream_download
+from ..downloaders import FTPDownloader, HTTPDownloader
+from ..hashes import file_hash, hash_matches
+from ..utils import get_logger, os_cache, temporary_file
 from .utils import (
-    pooch_test_url,
+    capture_log,
+    check_large_data,
+    check_tiny_data,
     data_over_ftp,
+    mirror_directory,
+    pooch_test_dataverse_url,
     pooch_test_figshare_url,
+    pooch_test_registry,
+    pooch_test_url,
     pooch_test_zenodo_url,
     pooch_test_zenodo_with_slash_url,
-    pooch_test_dataverse_url,
-    pooch_test_registry,
-    check_tiny_data,
-    check_large_data,
-    capture_log,
-    mirror_directory,
 )
 
 DATA_DIR = str(Path(__file__).parent / "data")

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -519,7 +519,7 @@ def test_check_availability_on_ftp(ftpserver):
 def test_check_availability_invalid_downloader():
     "Should raise an exception if the downloader doesn't support this"
 
-    def downloader(url, output, pooch):  # pylint: disable=unused-argument
+    def downloader(url, output, pooch):  # noqa: ARG001
         "A downloader that doesn't support check_only"
         return None
 

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -506,7 +506,7 @@ def test_check_availability_on_ftp(ftpserver):
             path=DATA_DIR,
             base_url=url.replace("tiny-data.txt", ""),
             registry={
-                "tiny-data.txt": "baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d",
+                "tiny-data.txt": "baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d",  # noqa: E501
                 "doesnot_exist.zip": "jdjdjdjdflld",
             },
         )

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -7,6 +7,7 @@
 """
 Test the downloader classes and functions separately from the Pooch core.
 """
+
 import os
 import sys
 from tempfile import TemporaryDirectory
@@ -25,28 +26,27 @@ except ImportError:
 
 from .. import Pooch
 from ..downloaders import (
-    HTTPDownloader,
-    FTPDownloader,
-    SFTPDownloader,
-    DOIDownloader,
-    choose_downloader,
-    FigshareRepository,
-    ZenodoRepository,
     DataverseRepository,
+    DOIDownloader,
+    FigshareRepository,
+    FTPDownloader,
+    HTTPDownloader,
+    SFTPDownloader,
+    ZenodoRepository,
+    choose_downloader,
     doi_to_url,
 )
 from ..processors import Unzip
 from .utils import (
-    pooch_test_url,
     check_large_data,
     check_tiny_data,
     data_over_ftp,
+    pooch_test_dataverse_url,
     pooch_test_figshare_url,
+    pooch_test_url,
     pooch_test_zenodo_url,
     pooch_test_zenodo_with_slash_url,
-    pooch_test_dataverse_url,
 )
-
 
 BASEURL = pooch_test_url()
 FIGSHAREURL = pooch_test_figshare_url()

--- a/pooch/tests/test_hashes.py
+++ b/pooch/tests/test_hashes.py
@@ -36,7 +36,7 @@ REGISTRY = (
     "tiny-data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d\n"
 )
 REGISTRY_RECURSIVE = (
-    "subdir/tiny-data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d\n"
+    "subdir/tiny-data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d\n"  # noqa: E501
     "tiny-data.txt baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d\n"
 )
 TINY_DATA_HASHES_HASHLIB = {

--- a/pooch/tests/test_hashes.py
+++ b/pooch/tests/test_hashes.py
@@ -8,6 +8,7 @@
 """
 Test the hash calculation and checking functions.
 """
+
 import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -24,9 +25,9 @@ except ImportError:
 
 from ..core import Pooch
 from ..hashes import (
-    make_registry,
     file_hash,
     hash_matches,
+    make_registry,
 )
 from .utils import check_tiny_data, mirror_directory
 

--- a/pooch/tests/test_integration.py
+++ b/pooch/tests/test_integration.py
@@ -8,15 +8,16 @@
 """
 Test the entire process of creating a Pooch and using it.
 """
+
 import os
 import shutil
 from pathlib import Path
 
 import pytest
 
-from .. import create, os_cache
 from .. import __version__ as full_version
-from .utils import check_tiny_data, capture_log
+from .. import create, os_cache
+from .utils import capture_log, check_tiny_data
 
 
 @pytest.mark.network

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -7,17 +7,16 @@
 """
 Test the processor hooks
 """
+
+import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import warnings
 
 import pytest
 
 from .. import Pooch
-from ..processors import Unzip, Untar, Decompress
-
-from .utils import pooch_test_url, pooch_test_registry, check_tiny_data, capture_log
-
+from ..processors import Decompress, Untar, Unzip
+from .utils import capture_log, check_tiny_data, pooch_test_registry, pooch_test_url
 
 REGISTRY = pooch_test_registry()
 BASEURL = pooch_test_url()

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -7,19 +7,20 @@
 """
 Test the utility functions.
 """
+
 import os
 import shutil
-import time
-from pathlib import Path
 import tempfile
+import time
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from pathlib import Path
 from tempfile import TemporaryDirectory
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 
 import pytest
 
 from ..utils import (
-    parse_url,
     make_local_storage,
+    parse_url,
     temporary_file,
     unique_file_name,
 )

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -81,7 +81,7 @@ def test_make_local_storage_parallel(pool, monkeypatch):
 def test_local_storage_makedirs_permissionerror(monkeypatch):
     "Should warn the user when can't create the local data dir"
 
-    def mockmakedirs(path, exist_ok=False):  # pylint: disable=unused-argument
+    def mockmakedirs(path, exist_ok=False):  # noqa: ARG001
         "Raise an exception to mimic permission issues"
         raise PermissionError("Fake error")
 
@@ -104,7 +104,7 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
     # This is a separate function because there should be a warning if the data
     # dir already exists but we can't write to it.
 
-    def mocktempfile(**kwargs):  # pylint: disable=unused-argument
+    def mocktempfile(**kwargs):  # noqa: ARG001
         "Raise an exception to mimic permission issues"
         raise PermissionError("Fake error")
 

--- a/pooch/tests/test_version.py
+++ b/pooch/tests/test_version.py
@@ -7,6 +7,7 @@
 """
 Test the version.
 """
+
 from packaging.version import Version
 
 import pooch

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -7,13 +7,14 @@
 """
 Utilities for testing code.
 """
-import os
+
 import io
 import logging
+import os
 import shutil
 import stat
-from pathlib import Path
 from contextlib import contextmanager
+from pathlib import Path
 
 from .. import __version__ as full_version
 from ..utils import check_version, get_logger

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -140,16 +140,16 @@ def pooch_test_registry():
 
     """
     registry = {
-        "tiny-data.txt": "baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d",
-        "large-data.txt": "98de171fb320da82982e6bf0f3994189fff4b42b23328769afce12bdd340444a",
-        "subdir/tiny-data.txt": "baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d",
-        "tiny-data.zip": "0d49e94f07bc1866ec57e7fd1b93a351fba36842ec9b13dd50bf94e8dfa35cbb",
+        "tiny-data.txt": "baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d",  # noqa: E501
+        "large-data.txt": "98de171fb320da82982e6bf0f3994189fff4b42b23328769afce12bdd340444a",  # noqa: E501
+        "subdir/tiny-data.txt": "baee0894dba14b12085eacb204284b97e362f4f3e5a5807693cc90ef415c1b2d",  # noqa: E501
+        "tiny-data.zip": "0d49e94f07bc1866ec57e7fd1b93a351fba36842ec9b13dd50bf94e8dfa35cbb",  # noqa: E501
         "store.zip": "0498d2a001e71051bbd2acd2346f38da7cbd345a633cb7bf0f8a20938714b51a",
-        "tiny-data.tar.gz": "41503f083814f43a01a8e9a30c28d7a9fe96839a99727a7fdd0acf7cd5bab63b",
-        "store.tar.gz": "088c7f4e0f1859b1c769bb6065de24376f366374817ede8691a6ac2e49f29511",
-        "tiny-data.txt.bz2": "753663687a4040c90c8578061867d1df623e6aa8011c870a5dbd88ee3c82e306",
-        "tiny-data.txt.gz": "2e2da6161291657617c32192dba95635706af80c6e7335750812907b58fd4b52",
-        "tiny-data.txt.xz": "99dcb5c32a6e916344bacb4badcbc2f2b6ee196977d1d8187610c21e7e607765",
+        "tiny-data.tar.gz": "41503f083814f43a01a8e9a30c28d7a9fe96839a99727a7fdd0acf7cd5bab63b",  # noqa: E501
+        "store.tar.gz": "088c7f4e0f1859b1c769bb6065de24376f366374817ede8691a6ac2e49f29511",  # noqa: E501
+        "tiny-data.txt.bz2": "753663687a4040c90c8578061867d1df623e6aa8011c870a5dbd88ee3c82e306",  # noqa: E501
+        "tiny-data.txt.gz": "2e2da6161291657617c32192dba95635706af80c6e7335750812907b58fd4b52",  # noqa: E501
+        "tiny-data.txt.xz": "99dcb5c32a6e916344bacb4badcbc2f2b6ee196977d1d8187610c21e7e607765",  # noqa: E501
     }
     return registry
 

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -7,18 +7,18 @@
 """
 Misc utilities
 """
+
+import hashlib
 import logging
 import os
 import tempfile
-import hashlib
+import warnings
+from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import urlsplit
-from contextlib import contextmanager
-import warnings
 
 import platformdirs
 from packaging.version import Version
-
 
 LOGGER = logging.Logger("pooch")
 LOGGER.addHandler(logging.StreamHandler())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ select = [
     # "SIM", # flake8-simplify
     "I",   # isort
 ]
+ignore = [
+    "UP015", # ignore redundant modes in `open` (it's ok to be explicit)
+]
 
 [tool.ruff.lint.per-file-ignores]
 # disable unused-imports errors on __init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,25 @@ notice = '''
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #'''
+
+[tool.ruff]
+line-length = 88
+exclude = [
+    "doc/_build",
+    "pooch/_version.py",
+]
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle
+    "F",   # Pyflakes
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "ARG", # unused arguments
+    # "SIM", # flake8-simplify
+    "I",   # isort
+]
+
+[tool.ruff.lint.per-file-ignores]
+# disable unused-imports errors on __init__.py
+"__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,17 +82,38 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = [
-    "E",   # pycodestyle
-    "F",   # Pyflakes
-    "UP",  # pyupgrade
-    "B",   # flake8-bugbear
-    "ARG", # unused arguments
-    # "SIM", # flake8-simplify
-    "I",   # isort
+extend-select = [
+  "ARG",      # flake8-unused-arguments
+  "B",        # flake8-bugbear
+  "C4",       # flake8-comprehensions
+  "EM",       # flake8-errmsg
+  "EXE",      # flake8-executable
+  "FURB",     # refurb
+  "G",        # flake8-logging-format
+  "I",        # isort
+  "ICN",      # flake8-import-conventions
+  "NPY",      # NumPy specific rules
+  "PD",       # pandas-vet
+  "PGH",      # pygrep-hooks
+  "PIE",      # flake8-pie
+  "PL",       # pylint
+  "PT",       # flake8-pytest-style
+  "PTH",      # flake8-use-pathlib
+  "PYI",      # flake8-pyi
+  "RET",      # flake8-return
+  "RUF",      # Ruff-specific
+  "SIM",      # flake8-simplify
+  "T20",      # flake8-print
+  "UP",       # pyupgrade
+  "YTT",      # flake8-2020
 ]
 ignore = [
     "UP015", # ignore redundant modes in `open` (it's ok to be explicit)
+    "ISC001",   # Conflicts with formatter
+    "PLR09",    # Too many <...>
+    "PLR2004",  # Magic value used in comparison
+    "PT001",    # conventions for parenthesis on pytest.fixture
+    "RET504",   # unnecessary assignment: allow to assign and return
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Start replacing `pylint`, `flake8` and `black` for `ruff` to check style of the code and to autoformat it. Check for `isort` rules with `ruff`.

TODO:
- [ ] solve remaining errors
- [ ] Remove pylint and flake8 related files
- [ ] Ensure no pylint or flake leftover (`git grep pylint`, `git grep flake`).
