### PR TITLE
Drop support for Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           - optional
         include:
           - dependencies: oldest
-            python: "3.7"
+            python: "3.9"
           - dependencies: latest
             python: "3.11"
           - dependencies: optional
@@ -53,7 +53,7 @@ jobs:
           # test on macos-13 (x86) using oldest dependencies and python 3.7
           - os: macos-13
             dependencies: oldest
-            python: "3.7"
+            python: "3.9"
         exclude:
           # don't test on macos-latest (arm64) with oldest dependencies
           - os: macos-latest

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -47,7 +47,7 @@ There are different ways to install Pooch:
 Which Python?
 -------------
 
-You'll need **Python >= 3.7**. See :ref:`python-versions` if you
+You'll need **Python >= 3.9**. See :ref:`python-versions` if you
 require support for older versions.
 
 .. _dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,13 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
     "platformdirs >= 2.5.0",
     "packaging >= 20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.9"
 dependencies = [


### PR DESCRIPTION
Drop support for Python <=3.8 since they have all reach their EOL.
