### PR TITLE
Extend support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,9 @@ jobs:
           - dependencies: oldest
             python: "3.7"
           - dependencies: latest
-            python: "3.11"
+            python: "3.13"
           - dependencies: optional
-            python: "3.11"
+            python: "3.13"
           # test on macos-13 (x86) using oldest dependencies and python 3.7
           - os: macos-13
             dependencies: oldest

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - python==3.11
+    - python==3.13
     - pip
     # Run
     - requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.7"
 dependencies = [


### PR DESCRIPTION
Run tests on CI using Python 3.13 to ensure Pooch works properly on latest version of Python.
