### PR TITLE
Autoformat Pooch with ruff

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,11 +4,10 @@
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
-import os
 import datetime
+import os
 
 import pooch
-
 
 # Project information
 # -----------------------------------------------------------------------------

--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -7,20 +7,18 @@
 # pylint: disable=missing-docstring,import-outside-toplevel,import-self
 #
 # Import functions/classes to make the API
-from .core import Pooch, create, retrieve
-from .utils import os_cache, check_version, get_logger
-from .hashes import file_hash, make_registry
-from .downloaders import (
-    HTTPDownloader,
-    FTPDownloader,
-    SFTPDownloader,
-    DOIDownloader,
-)
-from .processors import Unzip, Untar, Decompress
-
 # This file is generated automatically by setuptools_scm
 from . import _version
-
+from .core import Pooch, create, retrieve
+from .downloaders import (
+    DOIDownloader,
+    FTPDownloader,
+    HTTPDownloader,
+    SFTPDownloader,
+)
+from .hashes import file_hash, make_registry
+from .processors import Decompress, Untar, Unzip
+from .utils import check_version, get_logger, os_cache
 
 # Add a "v" to the version number
 __version__ = f"v{_version.version}"

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -7,25 +7,25 @@
 """
 The main Pooch class and a factory function for it.
 """
-import os
-import time
+
 import contextlib
-from pathlib import Path
+import os
 import shlex
 import shutil
+import time
+from pathlib import Path
 
-
-from .hashes import hash_matches, file_hash
+from .downloaders import DOIDownloader, choose_downloader, doi_to_repository
+from .hashes import file_hash, hash_matches
 from .utils import (
+    cache_location,
     check_version,
     get_logger,
     make_local_storage,
-    cache_location,
-    temporary_file,
     os_cache,
+    temporary_file,
     unique_file_name,
 )
-from .downloaders import DOIDownloader, choose_downloader, doi_to_repository
 
 
 def retrieve(

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -7,10 +7,10 @@
 """
 The classes that actually handle the downloads.
 """
+
+import ftplib
 import os
 import sys
-import ftplib
-
 import warnings
 
 from .utils import parse_url
@@ -171,9 +171,7 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
         if self.progressbar is True and tqdm is None:
             raise ValueError("Missing package 'tqdm' required for progress bars.")
 
-    def __call__(
-        self, url, output_file, pooch, check_only=False
-    ):  # pylint: disable=R0914
+    def __call__(self, url, output_file, pooch, check_only=False):  # pylint: disable=R0914
         """
         Download the given URL over HTTP to the given output file.
 

--- a/pooch/hashes.py
+++ b/pooch/hashes.py
@@ -7,8 +7,9 @@
 """
 Calculating and checking file hashes.
 """
-import hashlib
+
 import functools
+import hashlib
 from pathlib import Path
 
 # From the docs: https://docs.python.org/3/library/hashlib.html#hashlib.new

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -8,14 +8,15 @@
 """
 Post-processing hooks
 """
+
 import abc
-import os
 import bz2
 import gzip
 import lzma
+import os
 import shutil
-from zipfile import ZipFile
 from tarfile import TarFile
+from zipfile import ZipFile
 
 from .utils import get_logger
 

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -8,6 +8,7 @@
 """
 Test the core class and factory function.
 """
+
 import hashlib
 import os
 from pathlib import Path
@@ -15,26 +16,24 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
-from ..core import create, Pooch, retrieve, download_action, stream_download
-from ..utils import get_logger, temporary_file, os_cache
-from ..hashes import file_hash, hash_matches
-
 # Import the core module so that we can monkeypatch some functions
 from .. import core
-from ..downloaders import HTTPDownloader, FTPDownloader
-
+from ..core import Pooch, create, download_action, retrieve, stream_download
+from ..downloaders import FTPDownloader, HTTPDownloader
+from ..hashes import file_hash, hash_matches
+from ..utils import get_logger, os_cache, temporary_file
 from .utils import (
-    pooch_test_url,
+    capture_log,
+    check_large_data,
+    check_tiny_data,
     data_over_ftp,
+    mirror_directory,
+    pooch_test_dataverse_url,
     pooch_test_figshare_url,
+    pooch_test_registry,
+    pooch_test_url,
     pooch_test_zenodo_url,
     pooch_test_zenodo_with_slash_url,
-    pooch_test_dataverse_url,
-    pooch_test_registry,
-    check_tiny_data,
-    check_large_data,
-    capture_log,
-    mirror_directory,
 )
 
 DATA_DIR = str(Path(__file__).parent / "data")

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -7,6 +7,7 @@
 """
 Test the downloader classes and functions separately from the Pooch core.
 """
+
 import os
 import sys
 from tempfile import TemporaryDirectory
@@ -25,28 +26,27 @@ except ImportError:
 
 from .. import Pooch
 from ..downloaders import (
-    HTTPDownloader,
-    FTPDownloader,
-    SFTPDownloader,
-    DOIDownloader,
-    choose_downloader,
-    FigshareRepository,
-    ZenodoRepository,
     DataverseRepository,
+    DOIDownloader,
+    FigshareRepository,
+    FTPDownloader,
+    HTTPDownloader,
+    SFTPDownloader,
+    ZenodoRepository,
+    choose_downloader,
     doi_to_url,
 )
 from ..processors import Unzip
 from .utils import (
-    pooch_test_url,
     check_large_data,
     check_tiny_data,
     data_over_ftp,
+    pooch_test_dataverse_url,
     pooch_test_figshare_url,
+    pooch_test_url,
     pooch_test_zenodo_url,
     pooch_test_zenodo_with_slash_url,
-    pooch_test_dataverse_url,
 )
-
 
 BASEURL = pooch_test_url()
 FIGSHAREURL = pooch_test_figshare_url()

--- a/pooch/tests/test_hashes.py
+++ b/pooch/tests/test_hashes.py
@@ -8,6 +8,7 @@
 """
 Test the hash calculation and checking functions.
 """
+
 import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -24,9 +25,9 @@ except ImportError:
 
 from ..core import Pooch
 from ..hashes import (
-    make_registry,
     file_hash,
     hash_matches,
+    make_registry,
 )
 from .utils import check_tiny_data, mirror_directory
 

--- a/pooch/tests/test_integration.py
+++ b/pooch/tests/test_integration.py
@@ -8,15 +8,16 @@
 """
 Test the entire process of creating a Pooch and using it.
 """
+
 import os
 import shutil
 from pathlib import Path
 
 import pytest
 
-from .. import create, os_cache
 from .. import __version__ as full_version
-from .utils import check_tiny_data, capture_log
+from .. import create, os_cache
+from .utils import capture_log, check_tiny_data
 
 
 @pytest.mark.network

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -7,17 +7,16 @@
 """
 Test the processor hooks
 """
+
+import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import warnings
 
 import pytest
 
 from .. import Pooch
-from ..processors import Unzip, Untar, Decompress
-
-from .utils import pooch_test_url, pooch_test_registry, check_tiny_data, capture_log
-
+from ..processors import Decompress, Untar, Unzip
+from .utils import capture_log, check_tiny_data, pooch_test_registry, pooch_test_url
 
 REGISTRY = pooch_test_registry()
 BASEURL = pooch_test_url()

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -7,19 +7,20 @@
 """
 Test the utility functions.
 """
+
 import os
 import shutil
-import time
-from pathlib import Path
 import tempfile
+import time
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from pathlib import Path
 from tempfile import TemporaryDirectory
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 
 import pytest
 
 from ..utils import (
-    parse_url,
     make_local_storage,
+    parse_url,
     temporary_file,
     unique_file_name,
 )

--- a/pooch/tests/test_version.py
+++ b/pooch/tests/test_version.py
@@ -7,6 +7,7 @@
 """
 Test the version.
 """
+
 from packaging.version import Version
 
 import pooch

--- a/pooch/tests/utils.py
+++ b/pooch/tests/utils.py
@@ -7,13 +7,14 @@
 """
 Utilities for testing code.
 """
-import os
+
 import io
 import logging
+import os
 import shutil
 import stat
-from pathlib import Path
 from contextlib import contextmanager
+from pathlib import Path
 
 from .. import __version__ as full_version
 from ..utils import check_version, get_logger

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -7,18 +7,18 @@
 """
 Misc utilities
 """
+
+import hashlib
 import logging
 import os
 import tempfile
-import hashlib
+import warnings
+from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import urlsplit
-from contextlib import contextmanager
-import warnings
 
 import platformdirs
 from packaging.version import Version
-
 
 LOGGER = logging.Logger("pooch")
 LOGGER.addHandler(logging.StreamHandler())


### PR DESCRIPTION
Run `make format` to autoformat Pooch codebase with Ruff.

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged. 
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
