### PR TITLE
Provide more descriptive errors when DOI request fails

### DIFF
--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -651,9 +651,7 @@ def doi_to_url(doi):
     response = requests.get(f"https://doi.org/{doi}", timeout=DEFAULT_TIMEOUT)
     url = response.url
     if 400 <= response.status_code < 600:
-        raise ValueError(
-            f"Archive with doi:{doi} not found (see {url}). Is the DOI correct?"
-        )
+        response.raise_for_status()
     return url
 
 

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -12,6 +12,7 @@ import sys
 from tempfile import TemporaryDirectory
 
 import pytest
+from requests import HTTPError
 
 # Mypy doesn't like assigning None like this.
 # Can just use a guard variable
@@ -103,9 +104,8 @@ def test_invalid_doi_repository():
 @pytest.mark.network
 def test_doi_url_not_found():
     "Should fail if the DOI is not found"
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(HTTPError):
         doi_to_url(doi="NOTAREALDOI")
-    assert "Is the DOI correct?" in str(exc.value)
 
 
 @pytest.mark.network


### PR DESCRIPTION
Raise the `requests` response to provide more informative errors when the status code is between 400 and 600.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**

Part of #456
