### PR TITLE
Avoid requests to Figshare from macOS in GH Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,12 @@ jobs:
         run: python -m pip freeze
 
       - name: Run the tests
-        run: make test
+        run:
+          if [ ${{ steps.sys-info.outputs.os-name }} == "macOS" ]; then
+            make EXTRA_PYTEST_ARGS="-m 'not figshare' test
+          else
+            make test
+          fi
 
       - name: Convert coverage report to XML for codecov
         run: coverage xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
         run: python -m pip freeze
 
       - name: Run the tests
-        run:
+        run: |
           echo ${{ runner.os }}
           if [ ${{ runner.os }} == "macOS" ]; then
             make EXTRA_PYTEST_ARGS="-m 'not figshare'" test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,7 +151,8 @@ jobs:
 
       - name: Run the tests
         run:
-          if [ ${{ steps.sys-info.outputs.os-name }} == "macOS" ]; then
+          echo ${{ runner.os }}
+          if [ ${{ runner.os }} == "macOS" ]; then
             make EXTRA_PYTEST_ARGS="-m 'not figshare' test
           else
             make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Build, package, test, and clean
 PROJECT=pooch
 TESTDIR=tmp-test-dir-with-unique-name
-PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
+PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs $(EXTRA_PYTEST_ARGS)
 LINT_FILES=$(PROJECT)
 CHECK_STYLE=$(PROJECT) doc
 

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -564,7 +564,9 @@ class DOIDownloader:  # pylint: disable=too-few-public-methods
     >>> downloader = DOIDownloader()
     >>> url = "doi:10.6084/m9.figshare.14763051.v1/tiny-data.txt"
     >>> # Not using with Pooch.fetch so no need to pass an instance of Pooch
-    >>> downloader(url=url, output_file="tiny-data.txt", pooch=None) # doctest: +SKIP
+    >>> downloader(
+    ...     url=url, output_file="tiny-data.txt", pooch=None
+    ... ) # doctest: +SKIP
     >>> os.path.exists("tiny-data.txt")
     True
     >>> with open("tiny-data.txt") as f:

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -567,13 +567,13 @@ class DOIDownloader:  # pylint: disable=too-few-public-methods
     >>> downloader(
     ...     url=url, output_file="tiny-data.txt", pooch=None
     ... ) # doctest: +SKIP
-    >>> os.path.exists("tiny-data.txt")
+    >>> os.path.exists("tiny-data.txt") # doctest: +SKIP
     True
-    >>> with open("tiny-data.txt") as f:
+    >>> with open("tiny-data.txt") as f: # doctest: +SKIP
     ...     print(f.read().strip())
     # A tiny data file for test purposes only
     1  2  3  4  5  6
-    >>> os.remove("tiny-data.txt")
+    >>> os.remove("tiny-data.txt") # doctest: +SKIP
 
     Same thing but for our Zenodo archive:
 

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -564,7 +564,7 @@ class DOIDownloader:  # pylint: disable=too-few-public-methods
     >>> downloader = DOIDownloader()
     >>> url = "doi:10.6084/m9.figshare.14763051.v1/tiny-data.txt"
     >>> # Not using with Pooch.fetch so no need to pass an instance of Pooch
-    >>> downloader(url=url, output_file="tiny-data.txt", pooch=None)
+    >>> downloader(url=url, output_file="tiny-data.txt", pooch=None) # doctest: +SKIP
     >>> os.path.exists("tiny-data.txt")
     True
     >>> with open("tiny-data.txt") as f:

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -140,7 +140,12 @@ def test_pooch_local(data_dir_mirror):
 @pytest.mark.network
 @pytest.mark.parametrize(
     "url",
-    [BASEURL, FIGSHAREURL, ZENODOURL, DATAVERSEURL],
+    [
+        BASEURL,
+        pytest.param(FIGSHAREURL, marks=pytest.mark.figshare),
+        ZENODOURL,
+        DATAVERSEURL,
+    ],
     ids=["https", "figshare", "zenodo", "dataverse"],
 )
 def test_pooch_custom_url(url):
@@ -166,7 +171,12 @@ def test_pooch_custom_url(url):
 @pytest.mark.network
 @pytest.mark.parametrize(
     "url",
-    [BASEURL, FIGSHAREURL, ZENODOURL, DATAVERSEURL],
+    [
+        BASEURL,
+        pytest.param(FIGSHAREURL, marks=pytest.mark.figshare),
+        ZENODOURL,
+        DATAVERSEURL,
+    ],
     ids=["https", "figshare", "zenodo", "dataverse"],
 )
 def test_pooch_download(url):
@@ -627,7 +637,7 @@ def test_stream_download(fname):
 @pytest.mark.network
 @pytest.mark.parametrize(
     "url",
-    [FIGSHAREURL, ZENODOURL, DATAVERSEURL],
+    [pytest.param(FIGSHAREURL, marks=pytest.mark.figshare), ZENODOURL, DATAVERSEURL],
     ids=["figshare", "zenodo", "dataverse"],
 )
 def test_load_registry_from_doi(url):

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -112,7 +112,11 @@ def test_doi_url_not_found():
 @pytest.mark.parametrize(
     "repository,doi",
     [
-        (FigshareRepository, "10.6084/m9.figshare.14763051.v1"),
+        pytest.param(
+            FigshareRepository,
+            "10.6084/m9.figshare.14763051.v1",
+            marks=pytest.mark.figshare,
+        ),
         (ZenodoRepository, "10.5281/zenodo.4924875"),
         (DataverseRepository, "10.11588/data/TKCFEF"),
     ],
@@ -130,7 +134,7 @@ def test_figshare_url_file_not_found(repository, doi):
 @pytest.mark.network
 @pytest.mark.parametrize(
     "url",
-    [FIGSHAREURL, ZENODOURL, DATAVERSEURL],
+    [pytest.param(FIGSHAREURL, marks=pytest.mark.figshare), ZENODOURL, DATAVERSEURL],
     ids=["figshare", "zenodo", "dataverse"],
 )
 def test_doi_downloader(url):
@@ -164,6 +168,7 @@ def test_zenodo_downloader_with_slash_in_fname():
 
 
 @pytest.mark.network
+@pytest.mark.figshare
 def test_figshare_unspecified_version():
     """
     Test if passing a Figshare url without a version warns about it, but still
@@ -183,6 +188,7 @@ def test_figshare_unspecified_version():
 
 
 @pytest.mark.network
+@pytest.mark.figshare
 @pytest.mark.parametrize(
     "version, missing, present",
     [
@@ -269,7 +275,10 @@ def test_downloader_progressbar_fails(downloader):
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")
 @pytest.mark.parametrize(
     "url,downloader",
-    [(BASEURL, HTTPDownloader), (FIGSHAREURL, DOIDownloader)],
+    [
+        (BASEURL, HTTPDownloader),
+        pytest.param(FIGSHAREURL, DOIDownloader, marks=pytest.mark.figshare),
+    ],
     ids=["http", "figshare"],
 )
 def test_downloader_progressbar(url, downloader, capsys):

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -63,7 +63,7 @@ DATAVERSEURL = pooch_test_dataverse_url()
     "url",
     [
         BASEURL + "tiny-data.txt",  # HTTPDownloader
-        FIGSHAREURL,  # DOIDownloader
+        ZENODOURL,  # DOIDownloader
     ],
 )
 def test_progressbar_kwarg_passed(url):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ write_to =  "pooch/_version.py"
 [tool.pytest.ini_options]
 markers = [
     "network: test requires network access",
+    "figshare: test make request to Figshare",
 ]
 
 [tool.burocrata]


### PR DESCRIPTION
- Add custom `figshare` marker to some tests
- Add `EXTRA_ARGS_PYTEST` variable to `Makefile`
- Don't make calls to Figshare from macOS in Actions



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**
<!--
Example: "Fixes #1234" / "See also #345" / "Relevant to #111"
Use keywords (e.g., Fixes, Closes) to create the links and automatically
close issues when this PR is merged.
See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
