### PR TITLE
Add pytest `figshare` mark to tests

### DIFF
--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -140,7 +140,12 @@ def test_pooch_local(data_dir_mirror):
 @pytest.mark.network
 @pytest.mark.parametrize(
     "url",
-    [BASEURL, FIGSHAREURL, ZENODOURL, DATAVERSEURL],
+    [
+        BASEURL,
+        pytest.param(FIGSHAREURL, marks=pytest.mark.figshare),
+        ZENODOURL,
+        DATAVERSEURL,
+    ],
     ids=["https", "figshare", "zenodo", "dataverse"],
 )
 def test_pooch_custom_url(url):
@@ -166,7 +171,12 @@ def test_pooch_custom_url(url):
 @pytest.mark.network
 @pytest.mark.parametrize(
     "url",
-    [BASEURL, FIGSHAREURL, ZENODOURL, DATAVERSEURL],
+    [
+        BASEURL,
+        pytest.param(FIGSHAREURL, marks=pytest.mark.figshare),
+        ZENODOURL,
+        DATAVERSEURL,
+    ],
     ids=["https", "figshare", "zenodo", "dataverse"],
 )
 def test_pooch_download(url):
@@ -627,7 +637,7 @@ def test_stream_download(fname):
 @pytest.mark.network
 @pytest.mark.parametrize(
     "url",
-    [FIGSHAREURL, ZENODOURL, DATAVERSEURL],
+    [pytest.param(FIGSHAREURL, marks=pytest.mark.figshare), ZENODOURL, DATAVERSEURL],
     ids=["figshare", "zenodo", "dataverse"],
 )
 def test_load_registry_from_doi(url):

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -63,7 +63,7 @@ DATAVERSEURL = pooch_test_dataverse_url()
     "url",
     [
         BASEURL + "tiny-data.txt",  # HTTPDownloader
-        FIGSHAREURL,  # DOIDownloader
+        ZENODOURL,  # DOIDownloader
     ],
 )
 def test_progressbar_kwarg_passed(url):
@@ -112,7 +112,11 @@ def test_doi_url_not_found():
 @pytest.mark.parametrize(
     "repository,doi",
     [
-        (FigshareRepository, "10.6084/m9.figshare.14763051.v1"),
+        pytest.param(
+            FigshareRepository,
+            "10.6084/m9.figshare.14763051.v1",
+            marks=pytest.mark.figshare,
+        ),
         (ZenodoRepository, "10.5281/zenodo.4924875"),
         (DataverseRepository, "10.11588/data/TKCFEF"),
     ],
@@ -130,7 +134,7 @@ def test_figshare_url_file_not_found(repository, doi):
 @pytest.mark.network
 @pytest.mark.parametrize(
     "url",
-    [FIGSHAREURL, ZENODOURL, DATAVERSEURL],
+    [pytest.param(FIGSHAREURL, marks=pytest.mark.figshare), ZENODOURL, DATAVERSEURL],
     ids=["figshare", "zenodo", "dataverse"],
 )
 def test_doi_downloader(url):
@@ -164,6 +168,7 @@ def test_zenodo_downloader_with_slash_in_fname():
 
 
 @pytest.mark.network
+@pytest.mark.figshare
 def test_figshare_unspecified_version():
     """
     Test if passing a Figshare url without a version warns about it, but still
@@ -183,6 +188,7 @@ def test_figshare_unspecified_version():
 
 
 @pytest.mark.network
+@pytest.mark.figshare
 @pytest.mark.parametrize(
     "version, missing, present",
     [
@@ -269,7 +275,10 @@ def test_downloader_progressbar_fails(downloader):
 @pytest.mark.skipif(tqdm is None, reason="requires tqdm")
 @pytest.mark.parametrize(
     "url,downloader",
-    [(BASEURL, HTTPDownloader), (FIGSHAREURL, DOIDownloader)],
+    [
+        (BASEURL, HTTPDownloader),
+        pytest.param(FIGSHAREURL, DOIDownloader, marks=pytest.mark.figshare),
+    ],
     ids=["http", "figshare"],
 )
 def test_downloader_progressbar(url, downloader, capsys):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ write_to =  "pooch/_version.py"
 [tool.pytest.ini_options]
 markers = [
     "network: test requires network access",
+    "figshare: test make request to Figshare",
 ]
 
 [tool.burocrata]


### PR DESCRIPTION
Add a pytest `figshare` mark to tests that make requests to Figshare. Such mark allows us to filter tests: use `pytest -v -m figshare` to only run tests with that mark, or use `pytest -v -m "not figshare` to run all test but the marked ones.



<!--
Thank you for contributing a pull request to Fatiando! 💖

👆🏽 ABOVE: Describe the changes proposed and WHY you made them.

👇🏽 BELOW: Link to any relevant issue or pull request.

Please ensure you have taken a look at the CONTRIBUTING.md file
in this repository (if available) and the general guidelines at
https://github.com/fatiando/community/blob/main/CONTRIBUTING.md
-->

**Relevant issues/PRs:**

Inspired in #480.

I'm splitting #480 in two PRs, so we can easily revert the one that don't run figshare tests in MacOS, but keeping the `figshare` marks if we desire to.
