### PR TITLE
Skip Figshare related tests on Actions under MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,13 @@ jobs:
         run: python -m pip freeze
 
       - name: Run the tests
-        run: make test
+        run: |
+          echo ${{ runner.os }}
+          if [ ${{ runner.os }} == "macOS" ]; then
+            make PYTEST_ARGS_EXTRA="-m 'not figshare'" test
+          else
+            make test
+          fi
 
       - name: Convert coverage report to XML for codecov
         run: coverage xml

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Build, package, test, and clean
 PROJECT=pooch
 TESTDIR=tmp-test-dir-with-unique-name
-PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs
+PYTEST_ARGS=--cov-config=../.coveragerc --cov-report=term-missing --cov=$(PROJECT) --doctest-modules -v --pyargs $(PYTEST_ARGS_EXTRA)
 LINT_FILES=$(PROJECT)
 CHECK_STYLE=$(PROJECT) doc
 

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -564,14 +564,16 @@ class DOIDownloader:  # pylint: disable=too-few-public-methods
     >>> downloader = DOIDownloader()
     >>> url = "doi:10.6084/m9.figshare.14763051.v1/tiny-data.txt"
     >>> # Not using with Pooch.fetch so no need to pass an instance of Pooch
-    >>> downloader(url=url, output_file="tiny-data.txt", pooch=None)
-    >>> os.path.exists("tiny-data.txt")
+    >>> downloader(
+    ...     url=url, output_file="tiny-data.txt", pooch=None
+    ... ) # doctest: +SKIP
+    >>> os.path.exists("tiny-data.txt") # doctest: +SKIP
     True
-    >>> with open("tiny-data.txt") as f:
+    >>> with open("tiny-data.txt") as f: # doctest: +SKIP
     ...     print(f.read().strip())
     # A tiny data file for test purposes only
     1  2  3  4  5  6
-    >>> os.remove("tiny-data.txt")
+    >>> os.remove("tiny-data.txt") # doctest: +SKIP
 
     Same thing but for our Zenodo archive:
 


### PR DESCRIPTION
Skip tests marked with `figshare` on Actions that use MacOS as runner. Those tests in CI were constantly failing, probably due to too many requests coming from GitHub. Add an optional `PYTEST_ARGS_EXTRA` variable to `Makefile` that can be used to pass extra arguments to `pytest`. Skip doctests that download files from Figshare.

**Relevant issues/PRs:**

Inspired in #480, follow up of #481.
