### PR TITLE
Remove comments for disabling pylint warnings

### DIFF
--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -4,7 +4,7 @@
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
-# pylint: disable=missing-docstring,import-outside-toplevel,import-self
+
 #
 # Import functions/classes to make the API
 # This file is generated automatically by setuptools_scm

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -801,7 +801,7 @@ def stream_download(
     was due to a network error.
     """
     # Lazy import requests to speed up import time
-    import requests.exceptions  # pylint: disable=C0415
+    import requests.exceptions  
 
     # Ensure the parent directory exists in case the file is in a subdirectory.
     # Otherwise, move will cause an error.

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -89,7 +89,7 @@ def choose_downloader(url, progressbar=False):
     return downloader
 
 
-class HTTPDownloader:  # pylint: disable=too-few-public-methods
+class HTTPDownloader:
     """
     Download manager for fetching files over HTTP/HTTPS.
 
@@ -173,7 +173,7 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
         if self.progressbar is True and tqdm is None:
             raise ValueError("Missing package 'tqdm' required for progress bars.")
 
-    def __call__(self, url, output_file, pooch, check_only=False):  # pylint: disable=R0914
+    def __call__(self, url, output_file, pooch, check_only=False):
         """
         Download the given URL over HTTP to the given output file.
 
@@ -200,7 +200,7 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
 
         """
         # Lazy import requests to speed up import time
-        import requests  # pylint: disable=C0415
+        import requests
 
         if check_only:
             timeout = self.kwargs.get("timeout", DEFAULT_TIMEOUT)
@@ -213,9 +213,9 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
         kwargs.setdefault("stream", True)
         ispath = not hasattr(output_file, "write")
         if ispath:
-            # pylint: disable=consider-using-with
+
             output_file = open(output_file, "w+b")
-            # pylint: enable=consider-using-with
+
         try:
             response = requests.get(url, timeout=timeout, **kwargs)
             response.raise_for_status()
@@ -260,7 +260,7 @@ class HTTPDownloader:  # pylint: disable=too-few-public-methods
         return None
 
 
-class FTPDownloader:  # pylint: disable=too-few-public-methods
+class FTPDownloader:
     """
     Download manager for fetching files over FTP.
 
@@ -356,9 +356,9 @@ class FTPDownloader:  # pylint: disable=too-few-public-methods
 
         ispath = not hasattr(output_file, "write")
         if ispath:
-            # pylint: disable=consider-using-with
+
             output_file = open(output_file, "w+b")
-            # pylint: enable=consider-using-with
+
         try:
             ftp.login(user=self.username, passwd=self.password, acct=self.account)
             command = f"RETR {parsed_url['path']}"
@@ -392,7 +392,7 @@ class FTPDownloader:  # pylint: disable=too-few-public-methods
         return None
 
 
-class SFTPDownloader:  # pylint: disable=too-few-public-methods
+class SFTPDownloader:
     """
     Download manager for fetching files over SFTP.
 
@@ -503,7 +503,7 @@ class SFTPDownloader:  # pylint: disable=too-few-public-methods
                 sftp.close()
 
 
-class DOIDownloader:  # pylint: disable=too-few-public-methods
+class DOIDownloader:
     """
     Download manager for fetching files from Digital Object Identifiers (DOIs).
 
@@ -645,7 +645,7 @@ def doi_to_url(doi):
 
     """
     # Lazy import requests to speed up import time
-    import requests  # pylint: disable=C0415
+    import requests
 
     # Use doi.org to resolve the DOI to the repository website.
     response = requests.get(f"https://doi.org/{doi}", timeout=DEFAULT_TIMEOUT)
@@ -710,9 +710,9 @@ def doi_to_repository(doi):
     return data_repository
 
 
-class DataRepository:  # pylint: disable=too-few-public-methods, missing-class-docstring
+class DataRepository:
     @classmethod
-    def initialize(cls, doi, archive_url):  # pylint: disable=unused-argument
+    def initialize(cls, doi, archive_url):
         """
         Initialize the data repository if the given URL points to a
         corresponding repository.
@@ -763,7 +763,7 @@ class DataRepository:  # pylint: disable=too-few-public-methods, missing-class-d
         raise NotImplementedError  # pragma: no cover
 
 
-class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstring
+class ZenodoRepository(DataRepository):
     base_api_url = "https://zenodo.org/api/records"
 
     def __init__(self, doi, archive_url):
@@ -803,7 +803,7 @@ class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstri
         """Cached API response from Zenodo"""
         if self._api_response is None:
             # Lazy import requests to speed up import time
-            import requests  # pylint: disable=C0415
+            import requests
 
             article_id = self.archive_url.split("/")[-1]
             self._api_response = requests.get(
@@ -916,7 +916,7 @@ class ZenodoRepository(DataRepository):  # pylint: disable=missing-class-docstri
             pooch.registry[filedata[key]] = checksum
 
 
-class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docstring
+class FigshareRepository(DataRepository):
     def __init__(self, doi, archive_url):
         self.archive_url = archive_url
         self.doi = doi
@@ -969,7 +969,7 @@ class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docst
         """Cached API response from Figshare"""
         if self._api_response is None:
             # Lazy import requests to speed up import time
-            import requests  # pylint: disable=C0415
+            import requests
 
             # Use the figshare API to find the article ID from the DOI
             article = requests.get(
@@ -1044,7 +1044,7 @@ class FigshareRepository(DataRepository):  # pylint: disable=missing-class-docst
             pooch.registry[filedata["name"]] = f"md5:{filedata['computed_md5']}"
 
 
-class DataverseRepository(DataRepository):  # pylint: disable=missing-class-docstring
+class DataverseRepository(DataRepository):
     def __init__(self, doi, archive_url):
         self.archive_url = archive_url
         self.doi = doi
@@ -1089,7 +1089,7 @@ class DataverseRepository(DataRepository):  # pylint: disable=missing-class-docs
         used prior and after the initialization.
         """
         # Lazy import requests to speed up import time
-        import requests  # pylint: disable=C0415
+        import requests
 
         parsed = parse_url(archive_url)
         response = requests.get(

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -4,7 +4,7 @@
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
-# pylint: disable=line-too-long
+
 """
 Post-processing hooks
 """
@@ -22,7 +22,7 @@ from zipfile import ZipFile
 from .utils import get_logger
 
 
-class ExtractorProcessor(abc.ABC):  # pylint: disable=too-few-public-methods
+class ExtractorProcessor(abc.ABC):  
     """
     Abstract base class for extractions from compressed archives.
 
@@ -138,7 +138,7 @@ class ExtractorProcessor(abc.ABC):  # pylint: disable=too-few-public-methods
         return fnames
 
 
-class Unzip(ExtractorProcessor):  # pylint: disable=too-few-public-methods
+class Unzip(ExtractorProcessor):  
     """
     Processor that unpacks a zip archive and returns a list of all files.
 
@@ -210,7 +210,7 @@ class Unzip(ExtractorProcessor):  # pylint: disable=too-few-public-methods
                     zip_file.extractall(members=subdir_members, path=extract_dir)
 
 
-class Untar(ExtractorProcessor):  # pylint: disable=too-few-public-methods
+class Untar(ExtractorProcessor):  
     """
     Processor that unpacks a tar archive and returns a list of all files.
 
@@ -289,7 +289,7 @@ class Untar(ExtractorProcessor):  # pylint: disable=too-few-public-methods
                     )
 
 
-class Decompress:  # pylint: disable=too-few-public-methods
+class Decompress:  
     """
     Processor that decompress a file and returns the decompressed version.
 

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -4,7 +4,7 @@
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
-# pylint: disable=redefined-outer-name
+
 """
 Test the core class and factory function.
 """
@@ -201,7 +201,7 @@ def test_pooch_download(url):
             assert log_file.getvalue() == ""
 
 
-class FakeHashMatches:  # pylint: disable=too-few-public-methods
+class FakeHashMatches:  
     "Create a fake version of hash_matches that fails n times"
 
     def __init__(self, nfailures):
@@ -237,7 +237,7 @@ def test_pooch_download_retry_off_by_default(monkeypatch):
         assert logs[0].endswith(f"'{path}'.")
 
 
-class FakeSleep:  # pylint: disable=too-few-public-methods
+class FakeSleep:  
     "Create a fake version of sleep that logs the specified times"
 
     def __init__(self):
@@ -529,7 +529,7 @@ def test_check_availability_on_ftp(ftpserver):
 def test_check_availability_invalid_downloader():
     "Should raise an exception if the downloader doesn't support this"
 
-    def downloader(url, output, pooch):  # pylint: disable=unused-argument
+    def downloader(url, output, pooch):  
         "A downloader that doesn't support check_only"
         return None
 
@@ -543,7 +543,7 @@ def test_check_availability_invalid_downloader():
 def test_fetch_with_downloader(capsys):
     "Setup a downloader function for fetch"
 
-    def download(url, output_file, pup):  # pylint: disable=unused-argument
+    def download(url, output_file, pup):  
         "Download through HTTP and warn that we're doing it"
         get_logger().info("downloader executed")
         HTTPDownloader()(url, output_file, pup)

--- a/pooch/tests/test_hashes.py
+++ b/pooch/tests/test_hashes.py
@@ -4,7 +4,7 @@
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
-# pylint: disable=redefined-outer-name
+
 """
 Test the hash calculation and checking functions.
 """
@@ -67,7 +67,7 @@ def data_dir_mirror(tmp_path):
 
 def test_make_registry(data_dir_mirror):
     "Check that the registry builder creates the right file names and hashes"
-    outfile = NamedTemporaryFile(delete=False)  # pylint: disable=consider-using-with
+    outfile = NamedTemporaryFile(delete=False)  
     # Need to close the file before writing to it.
     outfile.close()
     try:
@@ -88,7 +88,7 @@ def test_make_registry(data_dir_mirror):
 
 def test_make_registry_recursive(data_dir_mirror):
     "Check that the registry builder works in recursive mode"
-    outfile = NamedTemporaryFile(delete=False)  # pylint: disable=consider-using-with
+    outfile = NamedTemporaryFile(delete=False)  
     # Need to close the file before writing to it.
     outfile.close()
     try:

--- a/pooch/tests/test_integration.py
+++ b/pooch/tests/test_integration.py
@@ -4,7 +4,7 @@
 #
 # This code is part of the Fatiando a Terra project (https://www.fatiando.org)
 #
-# pylint: disable=redefined-outer-name
+
 """
 Test the entire process of creating a Pooch and using it.
 """

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -55,7 +55,7 @@ def test_make_local_storage_parallel(pool, monkeypatch):
     # recursions from the monkey patching.
     makedirs = os.makedirs
 
-    def mockmakedirs(path, exist_ok=False):  # pylint: disable=unused-argument
+    def mockmakedirs(path, exist_ok=False):  
         "Delay before calling makedirs"
         time.sleep(1.5)
         makedirs(path, exist_ok=exist_ok)
@@ -81,7 +81,7 @@ def test_make_local_storage_parallel(pool, monkeypatch):
 def test_local_storage_makedirs_permissionerror(monkeypatch):
     "Should warn the user when can't create the local data dir"
 
-    def mockmakedirs(path, exist_ok=False):  # pylint: disable=unused-argument
+    def mockmakedirs(path, exist_ok=False):  
         "Raise an exception to mimic permission issues"
         raise PermissionError("Fake error")
 
@@ -104,7 +104,7 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
     # This is a separate function because there should be a warning if the data
     # dir already exists but we can't write to it.
 
-    def mocktempfile(**kwargs):  # pylint: disable=unused-argument
+    def mocktempfile(**kwargs):  
         "Raise an exception to mimic permission issues"
         raise PermissionError("Fake error")
 

--- a/pooch/typing/__init__.py
+++ b/pooch/typing/__init__.py
@@ -49,7 +49,7 @@ class Downloader(Protocol):
     Class used to define the type definition for the downloader function.
     """
 
-    # pylint: disable=too-few-public-methods
+    
     def __call__(  # noqa: E704
         self,
         fname: str,

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -46,7 +46,7 @@ def file_hash(*args, **kwargs) -> Any:
     >>> os.remove(fname)
 
     """
-    # pylint: disable=import-outside-toplevel
+    
     from .hashes import file_hash as new_file_hash
 
     message = """


### PR DESCRIPTION
As part of the process of replacing `pylint` for Ruff, remove the comments that were intended to disable `pylint` warnings in code.
