### PR TITLE
Fix Ruff's ARG warnings across Pooch

### DIFF
--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -175,7 +175,7 @@ class HTTPDownloader:
             msg = "Missing package 'tqdm' required for progress bars."
             raise ValueError(msg)
 
-    def __call__(self, url, output_file, pooch, check_only=False):
+    def __call__(self, url, output_file, pooch, check_only=False):  # noqa: ARG002
         """
         Download the given URL over HTTP to the given output file.
 
@@ -319,7 +319,7 @@ class FTPDownloader:
             msg = "Missing package 'tqdm' required for progress bars."
             raise ValueError(msg)
 
-    def __call__(self, url, output_file, pooch, check_only=False):
+    def __call__(self, url, output_file, pooch, check_only=False):  # noqa: ARG002
         """
         Download the given URL over FTP to the given output file.
 
@@ -452,7 +452,7 @@ class SFTPDownloader:
         if errors:
             raise ValueError(" ".join(errors))
 
-    def __call__(self, url, output_file, pooch):
+    def __call__(self, url, output_file, pooch):  # noqa: ARG002
         """
         Download the given URL over SFTP to the given output file.
 
@@ -713,7 +713,7 @@ def doi_to_repository(doi):
 
 class DataRepository:
     @classmethod
-    def initialize(cls, doi, archive_url):
+    def initialize(cls, doi, archive_url):  # noqa: ARG003
         """
         Initialize the data repository if the given URL points to a
         corresponding repository.

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -74,7 +74,7 @@ class ExtractorProcessor(abc.ABC):
         MUST BE IMPLEMENTED BY CHILD CLASSES.
         """
 
-    def __call__(self, fname, action, pooch):
+    def __call__(self, fname, action, pooch):  # noqa: ARG002
         """
         Extract all files from the given archive.
 
@@ -340,7 +340,7 @@ class Decompress:
         self.method = method
         self.name = name
 
-    def __call__(self, fname, action, pooch):
+    def __call__(self, fname, action, pooch):  # noqa: ARG002
         """
         Decompress the given file.
 

--- a/pooch/tests/test_core.py
+++ b/pooch/tests/test_core.py
@@ -528,7 +528,7 @@ def test_check_availability_on_ftp(ftpserver):
 def test_check_availability_invalid_downloader():
     "Should raise an exception if the downloader doesn't support this"
 
-    def downloader(url, output, pooch):
+    def downloader(url, output, pooch):  # noqa: ARG001
         "A downloader that doesn't support check_only"
         return
 

--- a/pooch/tests/test_utils.py
+++ b/pooch/tests/test_utils.py
@@ -81,7 +81,7 @@ def test_make_local_storage_parallel(pool, monkeypatch):
 def test_local_storage_makedirs_permissionerror(monkeypatch):
     "Should warn the user when can't create the local data dir"
 
-    def mockmakedirs(path, exist_ok=False):
+    def mockmakedirs(path, exist_ok=False):  # noqa: ARG001
         "Raise an exception to mimic permission issues"
         msg = "Fake error"
         raise PermissionError(msg)
@@ -105,7 +105,7 @@ def test_local_storage_newfile_permissionerror(monkeypatch):
     # This is a separate function because there should be a warning if the data
     # dir already exists but we can't write to it.
 
-    def mocktempfile(**kwargs):
+    def mocktempfile(**kwargs):  # noqa: ARG001
         "Raise an exception to mimic permission issues"
         msg = "Fake error"
         raise PermissionError(msg)


### PR DESCRIPTION
Add `noqa` comments to ignore Ruff's warnings about unused arguments where that's the intention.

**Relevant issues/PRs:**

Part of #453 