### PR TITLE
fix: Change TAR filter type for Python>3.11

### DIFF
--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -255,7 +255,7 @@ class Untar(ExtractorProcessor):  # pylint: disable=too-few-public-methods
         This method receives an argument for the archive to extract and the
         destination path.
         """
-        filter_kwarg = {} if sys.version_info < (3, 12) else {"filter": "data"}
+        filter_kwarg = {} if sys.version_info < (3, 12) else {"filter": "tar"}
         with TarFile.open(fname, "r") as tar_file:
             if self.members is None:
                 get_logger().info(


### PR DESCRIPTION
This is an attempt to resolve #518 by changing the filter type used for `tarfile` in the `Untar` processor class. Specifically, this switches the filter from `"data"` to `"tar"`, both of which are documented here https://docs.python.org/3/library/tarfile.html#default-named-filters This may allow for broader support for unpacking TAR archives that are complex or configured strangely.

Importantly, this also changes the filter to a "less restrictive" type, which could potentially lead to security issues.

On my local machine, all tests that don't have the `network` pytest mark pass fine.

**Relevant issues/PRs:**
Fixes #518 