### PR TITLE
Ignore Ruff PLC warnings on lazy imports

### DIFF
--- a/pooch/__init__.py
+++ b/pooch/__init__.py
@@ -50,7 +50,7 @@ def test(doctest=True, verbose=True, coverage=False):  # noqa: PT028
         failed.
 
     """
-    import pytest
+    import pytest  # noqa: PLC0415
 
     package = __name__
     args = []

--- a/pooch/core.py
+++ b/pooch/core.py
@@ -807,7 +807,7 @@ def stream_download(
     was due to a network error.
     """
     # Lazy import requests to speed up import time
-    import requests.exceptions
+    import requests.exceptions  # noqa: PLC0415
 
     # Ensure the parent directory exists in case the file is in a subdirectory.
     # Otherwise, move will cause an error.

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -210,7 +210,7 @@ class HTTPDownloader:
 
         """
         # Lazy import requests to speed up import time
-        import requests
+        import requests  # noqa: PLC0415
 
         if check_only:
             timeout = self.kwargs.get("timeout", DEFAULT_TIMEOUT)
@@ -681,7 +681,7 @@ def doi_to_url(doi, **kwargs):
 
     """
     # Lazy import requests to speed up import time
-    import requests
+    import requests  # noqa: PLC0415
 
     # Use doi.org to resolve the DOI to the repository website.
     response = requests.get(
@@ -850,7 +850,7 @@ class ZenodoRepository(DataRepository):
         """Cached API response from Zenodo"""
         if self._api_response is None:
             # Lazy import requests to speed up import time
-            import requests
+            import requests  # noqa: PLC0415
 
             article_id = self.archive_url.split("/")[-1]
             self._api_response = requests.get(
@@ -1021,7 +1021,7 @@ class FigshareRepository(DataRepository):
         """Cached API response from Figshare"""
         if self._api_response is None:
             # Lazy import requests to speed up import time
-            import requests
+            import requests  # noqa: PLC0415
 
             # Use the figshare API to find the article ID from the DOI
             article = requests.get(
@@ -1145,7 +1145,7 @@ class DataverseRepository(DataRepository):
         used prior and after the initialization.
         """
         # Lazy import requests to speed up import time
-        import requests
+        import requests  # noqa: PLC0415
 
         parsed = parse_url(archive_url)
         response = requests.get(

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -47,7 +47,7 @@ def file_hash(*args, **kwargs) -> Any:
 
     """
 
-    from .hashes import file_hash as new_file_hash
+    from .hashes import file_hash as new_file_hash  # noqa: PLC0415
 
     message = """
     Importing file_hash from pooch.utils is DEPRECATED. Please import from the


### PR DESCRIPTION
Ignore Ruff warnings about imports not happening at the top level when doing lazy imports within functions and methods.

**Relevant issues/PRs:**

Part of #453
