### PR TITLE
Remove unused import in test file

### DIFF
--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -9,7 +9,6 @@ Test the processor hooks
 """
 
 import re
-import warnings
 from pathlib import Path
 from tempfile import TemporaryDirectory
 


### PR DESCRIPTION
Remove a hanging unused import of `warnings` in test file.

**Relevant issues/PRs:**

Part of #453
