### PR TITLE
Ignore a few Ruff PLW warnings

### DIFF
--- a/pooch/core.py
+++ b/pooch/core.py
@@ -659,9 +659,9 @@ class Pooch:
 
             for linenum, line in enumerate(fin):
                 if isinstance(line, bytes):
-                    line = line.decode("utf-8")
+                    line = line.decode("utf-8")  # noqa: PLW2901
 
-                line = line.strip()
+                line = line.strip()  # noqa: PLW2901
                 # skip line comments
                 if line.startswith("#"):
                     continue

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -129,7 +129,7 @@ def test_unpacking(processor_class, extension, target_path, archive, members):
     if target_path is None:
         target_path = archive + extension + processor.suffix
     with TemporaryDirectory() as path:
-        path = Path(path)
+        path = Path(path)  # noqa: PLW2901
         true_paths, expected_log = _unpacking_expected_paths_and_logs(
             archive, members, path / target_path, processor_class.__name__
         )


### PR DESCRIPTION
Ignore a few lines that overwrite the loop variables (like `line` when reading a file).

**Relevant issues/PRs:**

Part of #453
