### PR TITLE
Fix Ruff SIM warnings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -12,10 +12,7 @@ import pooch
 # -----------------------------------------------------------------------------
 project = "Pooch"
 copyright = f"{datetime.date.today().year}, The {project} Developers"
-if len(pooch.__version__.split(".")) > 3:
-    version = "dev"
-else:
-    version = pooch.__version__
+version = "dev" if len(pooch.__version__.split(".")) > 3 else pooch.__version__
 
 
 # General configuration

--- a/pooch/downloaders.py
+++ b/pooch/downloaders.py
@@ -221,9 +221,12 @@ class HTTPDownloader:
         kwargs = self.kwargs.copy()
         timeout = kwargs.pop("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("stream", True)
+
         ispath = not hasattr(output_file, "write")
         if ispath:
-            output_file = open(output_file, "w+b")
+            # It's safe to ignore not using a context manager here (SIM115), since we
+            # are using the try...finally construct.
+            output_file = open(output_file, "w+b")  # noqa: SIM115
 
         try:
             response = requests.get(url, timeout=timeout, **kwargs)
@@ -366,7 +369,9 @@ class FTPDownloader:
 
         ispath = not hasattr(output_file, "write")
         if ispath:
-            output_file = open(output_file, "w+b")
+            # It's safe to ignore not using a context manager here (SIM115), since we
+            # are using the try...finally construct.
+            output_file = open(output_file, "w+b")  # noqa: SIM115
 
         try:
             ftp.login(user=self.username, passwd=self.password, acct=self.account)

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -386,9 +386,8 @@ class Decompress:
                 self.method,
             )
             module = self._compression_module(fname)
-            with open(decompressed, "w+b") as output:
-                with module.open(fname) as compressed:
-                    shutil.copyfileobj(compressed, output)
+            with open(decompressed, "w+b") as output, module.open(fname) as compressed:
+                shutil.copyfileobj(compressed, output)
         return decompressed
 
     def _compression_module(self, fname):

--- a/pooch/tests/test_downloaders.py
+++ b/pooch/tests/test_downloaders.py
@@ -224,12 +224,14 @@ def test_figshare_data_repository_versions(version, missing, present):
 @pytest.mark.network
 def test_ftp_downloader(ftpserver):
     "Test ftp downloader"
-    with data_over_ftp(ftpserver, "tiny-data.txt") as url:
-        with TemporaryDirectory() as local_store:
-            downloader = FTPDownloader(port=ftpserver.server_port)
-            outfile = os.path.join(local_store, "tiny-data.txt")
-            downloader(url, outfile, None)
-            check_tiny_data(outfile)
+    with (
+        data_over_ftp(ftpserver, "tiny-data.txt") as url,
+        TemporaryDirectory() as local_store,
+    ):
+        downloader = FTPDownloader(port=ftpserver.server_port)
+        outfile = os.path.join(local_store, "tiny-data.txt")
+        downloader(url, outfile, None)
+        check_tiny_data(outfile)
 
 
 @pytest.mark.network

--- a/pooch/tests/test_hashes.py
+++ b/pooch/tests/test_hashes.py
@@ -68,7 +68,7 @@ def data_dir_mirror(tmp_path):
 
 def test_make_registry(data_dir_mirror):
     "Check that the registry builder creates the right file names and hashes"
-    outfile = NamedTemporaryFile(delete=False)
+    outfile = NamedTemporaryFile(delete=False)  # noqa: SIM115
     # Need to close the file before writing to it.
     outfile.close()
     try:
@@ -89,7 +89,7 @@ def test_make_registry(data_dir_mirror):
 
 def test_make_registry_recursive(data_dir_mirror):
     "Check that the registry builder works in recursive mode"
-    outfile = NamedTemporaryFile(delete=False)
+    outfile = NamedTemporaryFile(delete=False)  # noqa: SIM115
     # Need to close the file before writing to it.
     outfile.close()
     try:

--- a/pooch/utils.py
+++ b/pooch/utils.py
@@ -299,7 +299,9 @@ def temporary_file(path: Optional[PathType] = None) -> Generator[str, None, None
         The path to the temporary file.
 
     """
-    tmp = tempfile.NamedTemporaryFile(delete=False, dir=path)  # type: ignore[type-var]
+    tmp = tempfile.NamedTemporaryFile(  # noqa: SIM115
+        delete=False, dir=path
+    )  # type: ignore[type-var]
     # Close the temp file so that it can be opened elsewhere
     tmp.close()
     try:


### PR DESCRIPTION
Ignore a few files being opened without a context manager. It's safe to do so because we are using the try...finally construct.


**Relevant issues/PRs:**

Part of #453
