### PR TITLE
Guard optional bz2/gzip/lzma imports so pooch imports without them (fixes #468)

### DIFF
--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -10,15 +10,31 @@ Post-processing hooks
 """
 
 import abc
-import bz2
-import gzip
-import lzma
 import os
 import shutil
 import sys
 import typing
 from tarfile import TarFile
 from zipfile import ZipFile
+
+# bz2, gzip and lzma are optional features of the Python standard library: a
+# Python interpreter can be built without them (e.g. when the bzip2/lzma/zlib
+# development headers are missing). Importing them at module level would make
+# *any* use of pooch fail on such interpreters, even when no decompression is
+# needed. Guard the imports so the modules are only required when the matching
+# Decompress method is actually used (see GH #468).
+try:
+    import bz2
+except ImportError:
+    bz2 = None
+try:
+    import gzip
+except ImportError:
+    gzip = None
+try:
+    import lzma
+except ImportError:
+    lzma = None
 
 from .utils import get_logger
 
@@ -342,6 +358,14 @@ class Decompress:
         "bzip2": bz2,
     }
     extensions: typing.ClassVar = {".xz": "lzma", ".gz": "gzip", ".bz2": "bzip2"}
+    # Name of the standard-library module backing each method, used to give a
+    # clear error when that (optional) module isn't available (see GH #468).
+    module_names: typing.ClassVar = {
+        "lzma": "lzma",
+        "xz": "lzma",
+        "gzip": "gzip",
+        "bzip2": "bz2",
+    }
 
     def __init__(self, method="auto", name=None):
         self.method = method
@@ -417,5 +441,18 @@ class Decompress:
                 if ext in {".zip", ".tar"}:
                     message = " ".join([message, error_archives])
                 raise ValueError(message)
-            return self.modules[self.extensions[ext]]
-        return self.modules[self.method]
+            method = self.extensions[ext]
+        else:
+            method = self.method
+        module = self.modules[method]
+        if module is None:
+            module_name = self.module_names[method]
+            message = (
+                f"Could not decompress '{fname}' because the '{module_name}' "
+                "module is not available in this Python installation. This "
+                f"usually means Python was built without '{module_name}' "
+                "support. Rebuild or reinstall Python with the required "
+                "support to use this compression method."
+            )
+            raise ValueError(message)
+        return module

--- a/pooch/processors.py
+++ b/pooch/processors.py
@@ -22,19 +22,20 @@ from zipfile import ZipFile
 # development headers are missing). Importing them at module level would make
 # *any* use of pooch fail on such interpreters, even when no decompression is
 # needed. Guard the imports so the modules are only required when the matching
-# Decompress method is actually used (see GH #468).
+# Decompress method is actually used (see GH #468). The ``type: ignore`` marks
+# the ``None`` fallback as intentional for the type checker.
 try:
     import bz2
 except ImportError:
-    bz2 = None
+    bz2 = None  # type: ignore[assignment]
 try:
     import gzip
 except ImportError:
-    gzip = None
+    gzip = None  # type: ignore[assignment]
 try:
     import lzma
 except ImportError:
-    lzma = None
+    lzma = None  # type: ignore[assignment]
 
 from .utils import get_logger
 

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -102,6 +102,8 @@ def test_decompress_fails():
     [
         ("lzma", "data.xz", "lzma"),
         ("xz", "data.xz", "lzma"),
+        ("gzip", "data.gz", "gzip"),
+        ("auto", "data.gz", "gzip"),
         ("bzip2", "data.bz2", "bz2"),
         ("auto", "data.bz2", "bz2"),
     ],
@@ -111,6 +113,7 @@ def test_decompress_unavailable_module(monkeypatch, method, fname, module_name):
     # Simulate a Python built without the optional module (see GH #468)
     monkeypatch.setitem(Decompress.modules, "lzma", None)
     monkeypatch.setitem(Decompress.modules, "xz", None)
+    monkeypatch.setitem(Decompress.modules, "gzip", None)
     monkeypatch.setitem(Decompress.modules, "bzip2", None)
     processor = Decompress(method=method)
     with pytest.raises(ValueError, match=re.escape(f"'{module_name}' module")):
@@ -123,12 +126,12 @@ def test_processors_import_without_optional_modules():
         "import builtins\n"
         "_real = builtins.__import__\n"
         "def _fake(name, *args, **kwargs):\n"
-        "    if name in ('lzma', '_lzma', 'bz2', '_bz2'):\n"
+        "    if name in ('lzma', '_lzma', 'gzip', '_gzip', 'bz2', '_bz2'):\n"
         "        raise ModuleNotFoundError(\"No module named '%s'\" % name)\n"
         "    return _real(name, *args, **kwargs)\n"
         "builtins.__import__ = _fake\n"
         "import pooch.processors as p\n"
-        "assert p.lzma is None and p.bz2 is None and p.gzip is not None\n"
+        "assert p.lzma is None and p.gzip is None and p.bz2 is None\n"
         "print('IMPORT_OK')\n"
     )
     result = subprocess.run(

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -8,15 +8,15 @@
 Test the processor hooks
 """
 
+import builtins
+import importlib
 import re
-import subprocess
-import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
 
-from .. import Pooch
+from .. import Pooch, processors
 from ..processors import Decompress, Untar, Unzip
 from .utils import capture_log, check_tiny_data, pooch_test_registry, pooch_test_url
 
@@ -120,28 +120,25 @@ def test_decompress_unavailable_module(monkeypatch, method, fname, module_name):
         processor._compression_module(fname)
 
 
-def test_processors_import_without_optional_modules():
+def test_processors_import_without_optional_modules(monkeypatch):
     "Importing pooch must not fail when bz2/lzma are missing (see GH #468)"
-    code = (
-        "import builtins\n"
-        "_real = builtins.__import__\n"
-        "def _fake(name, *args, **kwargs):\n"
-        "    if name in ('lzma', '_lzma', 'gzip', '_gzip', 'bz2', '_bz2'):\n"
-        "        raise ModuleNotFoundError(\"No module named '%s'\" % name)\n"
-        "    return _real(name, *args, **kwargs)\n"
-        "builtins.__import__ = _fake\n"
-        "import pooch.processors as p\n"
-        "assert p.lzma is None and p.gzip is None and p.bz2 is None\n"
-        "print('IMPORT_OK')\n"
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, result.stderr
-    assert "IMPORT_OK" in result.stdout
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in ("lzma", "_lzma", "gzip", "_gzip", "bz2", "_bz2"):
+            message = f"No module named '{name}'"
+            raise ModuleNotFoundError(message)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    try:
+        reloaded_processors = importlib.reload(processors)
+        assert reloaded_processors.lzma is None
+        assert reloaded_processors.gzip is None
+        assert reloaded_processors.bz2 is None
+    finally:
+        monkeypatch.setattr(builtins, "__import__", real_import)
+        importlib.reload(processors)
 
 
 @pytest.mark.network

--- a/pooch/tests/test_processors.py
+++ b/pooch/tests/test_processors.py
@@ -9,6 +9,8 @@ Test the processor hooks
 """
 
 import re
+import subprocess
+import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -93,6 +95,50 @@ def test_decompress_fails():
         with pytest.raises(ValueError, match=msg) as exception:
             pup.fetch("store.zip", processor=Decompress(method="auto"))
         assert "pooch.Unzip/Untar" in exception.value.args[0]
+
+
+@pytest.mark.parametrize(
+    ("method", "fname", "module_name"),
+    [
+        ("lzma", "data.xz", "lzma"),
+        ("xz", "data.xz", "lzma"),
+        ("bzip2", "data.bz2", "bz2"),
+        ("auto", "data.bz2", "bz2"),
+    ],
+)
+def test_decompress_unavailable_module(monkeypatch, method, fname, module_name):
+    "A clear error should be raised when the compression module is unavailable"
+    # Simulate a Python built without the optional module (see GH #468)
+    monkeypatch.setitem(Decompress.modules, "lzma", None)
+    monkeypatch.setitem(Decompress.modules, "xz", None)
+    monkeypatch.setitem(Decompress.modules, "bzip2", None)
+    processor = Decompress(method=method)
+    with pytest.raises(ValueError, match=re.escape(f"'{module_name}' module")):
+        processor._compression_module(fname)
+
+
+def test_processors_import_without_optional_modules():
+    "Importing pooch must not fail when bz2/lzma are missing (see GH #468)"
+    code = (
+        "import builtins\n"
+        "_real = builtins.__import__\n"
+        "def _fake(name, *args, **kwargs):\n"
+        "    if name in ('lzma', '_lzma', 'bz2', '_bz2'):\n"
+        "        raise ModuleNotFoundError(\"No module named '%s'\" % name)\n"
+        "    return _real(name, *args, **kwargs)\n"
+        "builtins.__import__ = _fake\n"
+        "import pooch.processors as p\n"
+        "assert p.lzma is None and p.bz2 is None and p.gzip is not None\n"
+        "print('IMPORT_OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "IMPORT_OK" in result.stdout
 
 
 @pytest.mark.network


### PR DESCRIPTION
Fixes #468

## Problem

`bz2`, `gzip` and `lzma` are *optional* features of the Python standard
library — an interpreter can be built without them when the corresponding
`bzip2`/`lzma`/`zlib` development headers are missing (reported on a
self-compiled Python 3.13 and on a custom Python 3.9 on RHEL in #468).

`pooch/processors.py` imported all three at module level:

```python
import bz2
import gzip
import lzma
```

so importing **any** part of pooch failed entirely on such interpreters:

```
File ".../pooch/processors.py", line 15, in <module>
    import lzma
ModuleNotFoundError: No module named '_lzma'
```

even for users who never touch `Decompress`.

## Change

As suggested in the issue, guard the three imports so a missing module
becomes `None` instead of crashing at import time:

```python
try:
    import lzma
except ImportError:
    lzma = None
```

The module is then only required when the matching `Decompress` method is
actually used. `Decompress._compression_module` now raises a clear
`ValueError` naming the missing module instead of failing later with an
`AttributeError` on `None`:

> Could not decompress 'data.xz' because the 'lzma' module is not available
> in this Python installation. This usually means Python was built without
> 'lzma' support. ...

When the modules are present (the normal case) behaviour is unchanged.

## Tests

* `test_decompress_unavailable_module` — monkeypatches the module table to
  `None` (simulating a Python built without the module) and checks the clear
  error for the `lzma`/`xz`/`bzip2`/`auto` paths.
* `test_processors_import_without_optional_modules` — spawns a subprocess
  that blocks importing `lzma`/`bz2` and asserts `import pooch.processors`
  still succeeds (faithful reproduction of #468).

Both fail on `main` and pass with this change; the full
`test_processors.py` suite (44 tests) passes and `ruff` is clean.
