### PR TITLE
fix: quote filenames when making registries

### DIFF
--- a/pooch/hashes.py
+++ b/pooch/hashes.py
@@ -10,6 +10,7 @@ Calculating and checking file hashes.
 
 import functools
 import hashlib
+import shlex
 from pathlib import Path
 
 # From the docs: https://docs.python.org/3/library/hashlib.html#hashlib.new
@@ -223,6 +224,6 @@ def make_registry(directory, output, recursive=True):
         # Only use Unix separators for the registry so that we don't go
         # insane dealing with file paths.
         outfile.writelines(
-            "{} {}\n".format(fname.replace("\\", "/"), fhash)
+            "{} {}\n".format(shlex.quote(fname.replace("\\", "/")), fhash)
             for fname, fhash in zip(files, hashes)
         )

--- a/pooch/tests/test_hashes.py
+++ b/pooch/tests/test_hashes.py
@@ -87,6 +87,23 @@ def test_make_registry(data_dir_mirror):
         os.remove(outfile.name)
 
 
+def test_make_registry_quotes_files_with_spaces(tmp_path):
+    "Check that files with spaces can be written and read back from a registry"
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    fname = "file with spaces.txt"
+    (data_dir / fname).write_text("content", encoding="utf-8")
+    registry_file = tmp_path / "registry.txt"
+
+    make_registry(data_dir, registry_file, recursive=False)
+
+    registry = registry_file.read_text(encoding="utf-8")
+    assert registry == f"'{fname}' {file_hash(data_dir / fname)}\n"
+    pup = Pooch(path=data_dir, base_url="some bogus URL", registry={})
+    pup.load_registry(registry_file)
+    assert pup.registry == {fname: file_hash(data_dir / fname)}
+
+
 def test_make_registry_recursive(data_dir_mirror):
     "Check that the registry builder works in recursive mode"
     outfile = NamedTemporaryFile(delete=False)  # noqa: SIM115


### PR DESCRIPTION
Fixes #369.

`Pooch.load_registry` already uses `shlex.split`, so filenames with spaces can be read when they are quoted. `make_registry` was still writing raw filenames, which made generated registries ambiguous for names like `LICENSE (copy)`.

This updates `make_registry` to quote the normalized registry filename with `shlex.quote` and adds a round-trip test for a filename containing spaces.

Verification:

```text
uv run --with pytest --with-editable . pytest pooch/tests/test_hashes.py -q
uv run --with pytest --with pytest-httpserver --with pytest-localftpserver --with-editable . pytest pooch/tests/test_hashes.py pooch/tests/test_core.py -q
uv run --with ruff ruff check pooch/hashes.py pooch/tests/test_hashes.py
uv run --with ruff ruff format --check pooch/hashes.py pooch/tests/test_hashes.py
git diff --check
```